### PR TITLE
DSNY095: Add total number of shows before pagination to search results

### DIFF
--- a/components/shows/show-detail/results.js
+++ b/components/shows/show-detail/results.js
@@ -2,7 +2,7 @@ import classes from './results.module.css'
 import Button from '@/components/ui/button'
 
 function Results (props) {
-  const { date, query, items, length } = props
+  const { date, query, items } = props
 
   const humanReadableDate = new Date(date).toLocaleDateString('en-US', {
     month: 'long',
@@ -12,7 +12,7 @@ function Results (props) {
   if (query) {
     return (
       <section className={classes.title}>
-        <h1>THER ARE {items.length} {query} EVENTS ...</h1>
+        <h1>THER ARE {items} {query} EVENTS ...</h1>
         <Button link='/shows'>show all events</Button>
       </section>
     )
@@ -20,7 +20,7 @@ function Results (props) {
 
   return (
     <section className={classes.title}>
-      <h1> There are {length} Events in {humanReadableDate}</h1>
+      <h1>Events in {humanReadableDate}</h1>
       <Button link='/shows'>show all events</Button>
     </section>
   )

--- a/helpers/hooks/useScrollRestorationGen.js
+++ b/helpers/hooks/useScrollRestorationGen.js
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export function useScrollRestorationGen() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!('scrollRestoration' in window.history)) return;
+
+    window.history.scrollRestoration = 'manual';
+
+    const onRouteChangeStart = () => {
+      const { scrollX, scrollY } = window;
+      const currentPage = window.location.search.split('page=')[1];
+      sessionStorage.setItem(router.asPath, JSON.stringify({ x: scrollX, y: scrollY, page: currentPage }));
+    };
+
+    const onRouteChangeComplete = (url) => {
+      const scrollPos = JSON.parse(sessionStorage.getItem(url));
+      if (scrollPos) {
+        window.scrollTo(scrollPos.x, scrollPos.y);
+        sessionStorage.removeItem(url); // Clean up after restoring
+      }
+    };
+
+    router.events.on('routeChangeStart', onRouteChangeStart);
+    router.events.on('routeChangeComplete', onRouteChangeComplete);
+
+    return () => {
+      router.events.off('routeChangeStart', onRouteChangeStart);
+      router.events.off('routeChangeComplete', onRouteChangeComplete);
+    };
+  }, [router]);
+}

--- a/pages/api/search/[query].js
+++ b/pages/api/search/[query].js
@@ -1,16 +1,30 @@
 import Show from '../../../models/show-model'
 import { connectDb } from '@/helpers/db-util';
+
 async function handler(req, res) {
-  const query = req.query.query;
+  const { query, page = 1, limit = 10 } = req.query;
 
   if (req.method === 'GET') {
     try {
       await connectDb();
     } catch (error) {
       console.error('Error connecting to database:', error);
+      res.status(500).json({ message: 'Error connecting to database' });
+      return;
     }
     try {
       const regexQuery = new RegExp(query, 'i');
+      const skip = (page - 1) * limit;
+
+      const totalShows = await Show.countDocuments({
+        $or: [
+          { title: { $regex: regexQuery } },
+          { genre: { $regex: regexQuery } },
+          { location: { $regex: regexQuery } },
+          { excerpt: { $regex: regexQuery } }
+        ]
+      });
+
       const documents = await Show.find({
         $or: [
           { title: { $regex: regexQuery } },
@@ -18,11 +32,11 @@ async function handler(req, res) {
           { location: { $regex: regexQuery } },
           { excerpt: { $regex: regexQuery } }
         ]
-      }).sort({ date: 1 });
+      }).sort({ date: 1 }).skip(skip).limit(Number(limit));
 
-      res.status(200).json({ shows: documents });
+      res.status(200).json({ shows: documents, totalShows });
     } catch (error) {
-      res.status(500).json({ message: 'Error fetching documents🚬🚬' });
+      res.status(500).json({ message: 'Error fetching documents' });
     }
   } else {
     res.status(405).end(); 

--- a/pages/search/[query].js
+++ b/pages/search/[query].js
@@ -6,29 +6,55 @@ import ErrorAlert from '@/components/ui/error-alert'
 import Button from '@/components/ui/button'
 import Head from 'next/head'
 import ShowGrid from '@/components/shows/show-grid'
+import Pagination from '@/components/ui/pagination'
+import { useScrollRestorationGen } from '@/helpers/hooks/useScrollRestorationGen'
 
 function GenSearchPage () {
   const [loadedShows, setLoadedShows] = useState([])
+  const [totalShows, setTotalShows] = useState(0) // Store total number of shows
+  const [totalPages, setTotalPages] = useState(1)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [isBottom, setIsBottom] = useState(false)
   const router = useRouter()
 
   const query = (router.query.query || '').toLowerCase()
 
-  const { data, error } = useSWR(`/api/search/${query}`, url =>
+  const { data, error } = useSWR(`/api/search/${query}?page=${currentPage}&limit=10`, url =>
     fetch(url).then(res => res.json())
   )
 
+  useScrollRestorationGen()
+
   useEffect(() => {
     if (data) {
-      const showsArr = []
-
-      for (const key in data.shows) {
-        showsArr.push({
-          ...data.shows[key]
-        })
-      }
+      const showsArr = data.shows.map(show => ({ ...show }))
       setLoadedShows(showsArr)
+      setTotalShows(data.totalShows) // Update total number of shows
+      setTotalPages(Math.ceil(data.totalShows / 10))
     }
   }, [data])
+
+  useEffect(() => {
+    const storedPage = JSON.parse(sessionStorage.getItem(router.asPath))?.page;
+    if (storedPage) {
+      setCurrentPage(parseInt(storedPage, 10));
+    }
+  }, [router.asPath]);
+
+  function handlePageChange (newPage) {
+    setCurrentPage(newPage)
+    router.push(`/search/${query}?page=${newPage}`, undefined, { shallow: true })
+  }
+
+  useEffect(() => {
+    function handleScroll() {
+      const bottom = Math.ceil(window.innerHeight + window.scrollY) >= document.documentElement.scrollHeight
+      setIsBottom(bottom)
+    }
+
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
 
   let pageHeadData = (
     <Head>
@@ -84,8 +110,15 @@ function GenSearchPage () {
   return (
     <>
       {pageHeadData}
-      <Results query={query} items={loadedShows} />
+      <Results query={query} items={totalShows} />
       <ShowGrid items={loadedShows} />
+      {isBottom && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
- Updated API to include total number of shows in the response before pagination.
- Modified GenSearchPage component to use the total number of shows returned by the API.
- Updated Results component to display the total number of shows.
- Ensured current page state is maintained using session storage for better user experience.