### PR TITLE
feat: add TV Eye scraper, shows pagination, and auto-delete cron

### DIFF
--- a/SCRAPERS.md
+++ b/SCRAPERS.md
@@ -15,7 +15,8 @@ scrapers/
 │   ├── extract.ts      # Claude Haiku call — shared by all scrapers
 │   └── ingest.ts       # POST to /api/shows — shared by all scrapers
 ├── venues/
-│   └── the-broadway.ts # one file per venue
+│   ├── the-broadway.ts # Squarespace-based calendar
+│   └── tv-eye.ts       # SeeTickets-based calendar
 └── run.ts              # runs all scrapers in sequence
 ```
 
@@ -26,23 +27,18 @@ scrapers/
 Run individually from the project root. Each venue has three scripts — pick the target environment:
 
 ```bash
-# Against local dev server (must be running on port 3000)
-npm run scrape:broadway:dev
-
-# Against production
-npm run scrape:broadway:prod
-
-# Custom env (set INGEST_URL yourself)
 npm run scrape:broadway
+npm run scrape:tv-eye
 ```
 
 ---
 
 ## How It Works
 
-1. **Playwright** navigates the venue's shows page and grabs `document.body.innerText`
-2. **Claude Haiku** extracts structured show JSON from the raw text
-3. **ingest.ts** POSTs each show to `/api/shows` with a bearer token — upserts by slug, safe to re-run
+1. **Playwright** navigates the venue's calendar page and scrapes list-level data (title, slug, date, time, price, genre, image)
+2. **Playwright** visits each event's detail page for the full description and best-quality image
+3. **Claude Haiku** receives all raw event data as formatted text blocks and extracts structured JSON
+4. **ingest.ts** POSTs each show to `/api/shows` with a bearer token — upserts by slug, safe to re-run
 
 ---
 
@@ -50,13 +46,81 @@ npm run scrape:broadway
 
 1. Create `scrapers/venues/venue-name.ts` — export `venue: VenueConfig` and `scrape(): Promise<string>`
 2. Add it to the scrapers array in `scrapers/run.ts`
-3. Add npm scripts in `package.json`:
+3. Add an npm script in `package.json`:
    ```json
-   "scrape:venue-name:dev": "INGEST_URL=http://localhost:3000/api/shows ts-node --project scrapers/tsconfig.json scrapers/venues/venue-name.ts",
-   "scrape:venue-name:prod": "INGEST_URL=https://distortnewyork.com/api/shows ts-node --project scrapers/tsconfig.json scrapers/venues/venue-name.ts"
+   "scrape:venue-name": "ts-node --project scrapers/tsconfig.json scrapers/venues/venue-name.ts"
    ```
 
-The only venue-specific code is the Playwright navigation. Everything else is shared.
+The only venue-specific code is Playwright DOM extraction. Everything else (Haiku call, ingest POST) is shared.
+
+---
+
+## Scraper Rules
+
+### Always visit the detail page
+Never rely on the list page alone for the event description. List pages often truncate or omit details entirely. Always open each event's detail page and pull the full description text.
+
+### Preserve the full description — don't summarize
+The `excerpt` field should contain the complete event details text, preserving paragraph breaks as `\n\n`. Haiku is instructed to pass it through as-is. This content populates the show's detail page on the site and is community-facing.
+
+### Use the full-size image
+Some ticketing platforms (e.g. SeeTickets) wrap event images in an `<a>` tag where the `href` is the original and the `img src` is a resized/compressed thumbnail. Always grab the `<a href>` for the full-size image.
+
+### Detect and skip venue fallback images
+Venues often have a generic fallback image for events with no uploaded art. Identify its filename and filter those events out before passing to Haiku — the site is image-first and generic logos look bad on show cards.
+
+Example:
+```typescript
+const VENUE_FALLBACK = 'tv-eye-e1673392710636.jpeg'
+.filter((c) => !c.image.includes(VENUE_FALLBACK))
+```
+
+### Cap scraping to 3 months out
+Only scrape shows within 3 months of today. Filter in Node after extracting list data, before visiting any detail pages — no point loading detail pages for shows that won't be ingested.
+
+```typescript
+const cutoff = new Date()
+cutoff.setMonth(cutoff.getMonth() + 3)
+.filter((c) => c.date && new Date(c.date) <= cutoff)
+```
+
+### Resolve partial dates before sending to Haiku
+Some venues (e.g. SeeTickets) provide dates like "Tue Jun 16" with no year. Resolve the year in Node before building the raw text — don't ask Haiku to guess. Logic: if the month/day has already passed this year, use next year.
+
+```typescript
+const year =
+  month < now.getMonth() || (month === now.getMonth() && day < now.getDate())
+    ? now.getFullYear() + 1
+    : now.getFullYear()
+```
+
+### Use `networkidle` for list pages, `domcontentloaded` for detail pages
+List pages often use JS-rendered widgets (SeeTickets, etc.) that need network activity to settle. Detail pages are typically server-rendered — `domcontentloaded` is faster and sufficient.
+
+### Handle detail page failures gracefully
+Wrap each detail page visit in try/catch/finally. Log the failure and close the page — don't let one bad event crash the whole scrape run.
+
+```typescript
+try {
+  // scrape detail
+} catch (err) {
+  console.error(`  ✗ Failed to load detail page for "${card.title}":`, err)
+} finally {
+  await detailPage.close()
+}
+```
+
+### Slugs are the deduplication key
+The ingest endpoint upserts by slug. Re-running a scraper is always safe. Make sure slugs are stable across runs — derive them from the venue's own URL structure, not from titles (which can change).
+
+---
+
+## Venue Reference
+
+| Venue | Platform | Calendar URL | Detail page selector |
+|---|---|---|---|
+| The Broadway | Squarespace | `/showcalendar` | `.eventitem-column-content .sqs-html-content` (multiple blocks, joined) |
+| TV Eye | SeeTickets | `/calendar/` | `.event-details` (on `wl.seetickets.us`) |
 
 ---
 

--- a/app/api/cron/delete-past-shows/route.ts
+++ b/app/api/cron/delete-past-shows/route.ts
@@ -1,0 +1,15 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function GET(request: NextRequest) {
+  const auth = request.headers.get('authorization')
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+  }
+
+  const nyDate = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' })
+  const cutoff = new Date(`${nyDate}T00:00:00.000Z`)
+
+  const { count } = await prisma.show.deleteMany({ where: { date: { lt: cutoff } } })
+  return NextResponse.json({ deleted: count, cutoff: cutoff.toISOString() })
+}

--- a/app/api/shows/route.ts
+++ b/app/api/shows/route.ts
@@ -10,7 +10,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json()
-    const { title, slug, date, genre, venueName, venueSlug, time, price, image, excerpt, rating, isFeatured } = body
+    const { title, slug, date, genre, venueName, venueSlug, time, price, image, excerpt, rating, isFeatured, ticketUrl } = body
 
     if (!title?.trim() || !slug?.trim() || !date || !venueName?.trim() || !venueSlug?.trim() || !image?.trim()) {
       return NextResponse.json({ message: 'Invalid show data' }, { status: 422 })
@@ -20,12 +20,13 @@ export async function POST(request: NextRequest) {
 
     await prisma.show.upsert({
       where: { slug },
-      update: { title, date: new Date(date), genre, venueId: venue.id, time, price, image, excerpt: excerpt ?? '', rating: rating ?? 0, isFeatured: isFeatured ?? false },
-      create: { title, slug, date: new Date(date), genre, venueId: venue.id, time, price, image, excerpt: excerpt ?? '', rating: rating ?? 0, isFeatured: isFeatured ?? false },
+      update: { title, date: new Date(date), genre, venueId: venue.id, time, price, image, excerpt: excerpt ?? '', ticketUrl: ticketUrl ?? '', rating: rating ?? 0, isFeatured: isFeatured ?? false },
+      create: { title, slug, date: new Date(date), genre, venueId: venue.id, time, price, image, excerpt: excerpt ?? '', ticketUrl: ticketUrl ?? '', rating: rating ?? 0, isFeatured: isFeatured ?? false },
     })
 
     return NextResponse.json({ message: 'Show upserted' }, { status: 201 })
-  } catch {
-    return NextResponse.json({ message: 'Internal server error' }, { status: 500 })
+  } catch (err) {
+    console.error('[api/shows] error:', err)
+    return NextResponse.json({ message: 'Internal server error', error: String(err) }, { status: 500 })
   }
 }

--- a/app/shows/page.tsx
+++ b/app/shows/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import ShowGrid from '@/components/shows/show-grid'
 import GenSearch from '@/components/shows/gen-search'
-import { getAllShows, searchShows } from '@/lib/shows'
+import Pagination from '@/components/shows/pagination'
+import { getAllShows, searchShows, SHOWS_PER_PAGE } from '@/lib/shows'
 
 export const metadata: Metadata = {
   title: 'All Shows',
@@ -10,19 +11,35 @@ export const metadata: Metadata = {
 }
 
 type Props = {
-  searchParams: Promise<{ q?: string }>
+  searchParams: Promise<{ q?: string; page?: string }>
 }
 
 export default async function ShowsPage({ searchParams }: Props) {
-  const { q } = await searchParams
-  const shows = q ? await searchShows(q) : await getAllShows()
+  const { q, page } = await searchParams
+  const currentPage = Math.max(1, parseInt(page ?? '1', 10) || 1)
+
+  if (q) {
+    const shows = await searchShows(q)
+    return (
+      <>
+        <Suspense fallback={null}>
+          <GenSearch />
+        </Suspense>
+        <ShowGrid items={shows} />
+      </>
+    )
+  }
+
+  const { items, total } = await getAllShows({ page: currentPage })
+  const totalPages = Math.max(1, Math.ceil(total / SHOWS_PER_PAGE))
 
   return (
     <>
       <Suspense fallback={null}>
         <GenSearch />
       </Suspense>
-      <ShowGrid items={shows} />
+      <ShowGrid items={items} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} basePath="/shows" />
     </>
   )
 }

--- a/components/shows/pagination.module.css
+++ b/components/shows/pagination.module.css
@@ -1,0 +1,55 @@
+.pagination {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--size-2);
+  margin-block: var(--size-8);
+}
+
+.pages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  gap: var(--size-1);
+}
+
+.page,
+.active,
+.nav {
+  display: inline-grid;
+  place-items: center;
+  min-width: 2.25rem;
+  height: 2.25rem;
+  padding-inline: var(--size-3);
+  border-radius: 0.5rem;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  font-variant-numeric: tabular-nums;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.page:hover,
+.nav:hover {
+  background-color: var(--color-fill);
+  color: var(--color-text);
+}
+
+.active {
+  background-color: var(--color-accent);
+  color: #fff;
+  pointer-events: none;
+}
+
+.nav[aria-disabled='true'] {
+  color: var(--color-text-tertiary);
+  pointer-events: none;
+}
+
+.ellipsis {
+  display: inline-grid;
+  place-items: center;
+  min-width: 2.25rem;
+  color: var(--color-text-tertiary);
+}

--- a/components/shows/pagination.tsx
+++ b/components/shows/pagination.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link'
+import classes from './pagination.module.css'
+
+type Props = {
+  currentPage: number
+  totalPages: number
+  basePath: string
+}
+
+function hrefFor(basePath: string, page: number): string {
+  return page === 1 ? basePath : `${basePath}?page=${page}`
+}
+
+function pageList(current: number, total: number): (number | 'ellipsis')[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1)
+  const pages: (number | 'ellipsis')[] = [1]
+  const start = Math.max(2, current - 1)
+  const end = Math.min(total - 1, current + 1)
+  if (start > 2) pages.push('ellipsis')
+  for (let i = start; i <= end; i++) pages.push(i)
+  if (end < total - 1) pages.push('ellipsis')
+  pages.push(total)
+  return pages
+}
+
+export default function Pagination({ currentPage, totalPages, basePath }: Props) {
+  if (totalPages <= 1) return null
+  const pages = pageList(currentPage, totalPages)
+  const prevPage = Math.max(1, currentPage - 1)
+  const nextPage = Math.min(totalPages, currentPage + 1)
+
+  return (
+    <nav className={classes.pagination} aria-label="Pagination">
+      <Link
+        href={hrefFor(basePath, prevPage)}
+        className={classes.nav}
+        aria-label="Previous page"
+        aria-disabled={currentPage === 1}
+        tabIndex={currentPage === 1 ? -1 : undefined}
+      >
+        ‹
+      </Link>
+      <ul className={classes.pages}>
+        {pages.map((p, i) =>
+          p === 'ellipsis' ? (
+            <li key={`e${i}`} className={classes.ellipsis} aria-hidden>
+              …
+            </li>
+          ) : (
+            <li key={p}>
+              <Link
+                href={hrefFor(basePath, p)}
+                className={p === currentPage ? classes.active : classes.page}
+                aria-current={p === currentPage ? 'page' : undefined}
+              >
+                {p}
+              </Link>
+            </li>
+          ),
+        )}
+      </ul>
+      <Link
+        href={hrefFor(basePath, nextPage)}
+        className={classes.nav}
+        aria-label="Next page"
+        aria-disabled={currentPage === totalPages}
+        tabIndex={currentPage === totalPages ? -1 : undefined}
+      >
+        ›
+      </Link>
+    </nav>
+  )
+}

--- a/components/shows/show-detail/show-content.module.css
+++ b/components/shows/show-detail/show-content.module.css
@@ -1,57 +1,94 @@
-
 .content {
   width: 95%;
-  max-width: 60rem;
-  margin: var(--size-8) auto;
-  font-size: var(--size-5);
-  line-height: var(--size-8);
+  max-width: 64rem;
+  margin-block: var(--size-8);
+  margin-inline: auto;
   background-color: var(--color-bg-elevated);
-  border-radius: 6px;
-  padding: var(--size-4);
-}
-
-.header {
-  padding-bottom: var(--size-8);
-  border-bottom: 8px solid var(--color-accent);
-  margin-bottom: var(--size-4);
+  border-radius: 12px;
+  padding: var(--size-5);
+  display: grid;
+  gap: var(--size-5);
 }
 
 .header h1 {
-  font-size: var(--size-8);
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+  line-height: 1.15;
   color: var(--color-accent);
   margin: 0;
-  line-height: initial;
-  text-align: center;
+  text-align: left;
+}
+
+.body {
+  display: grid;
+  gap: var(--size-5);
 }
 
 .image {
-  margin: var(--size-4) auto;
   width: 100%;
-  max-width: 600px;
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: var(--color-bg-elevated-2);
 }
 
 .image img {
-  object-fit: contain;
+  display: block;
   width: 100%;
   height: auto;
+  object-fit: cover;
 }
 
 .details {
-  text-align: center;
+  display: grid;
+  gap: var(--size-3);
+  align-content: start;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
-.details p {
+.details p,
+.details time {
   color: var(--color-text-secondary);
-  margin: var(--size-2) 0;
+  margin: 0;
+}
+
+.details .venue {
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: 1.125rem;
+}
+
+.excerpt {
+  color: var(--color-text);
+  white-space: pre-line;
+}
+
+.ticketLink {
+  justify-self: start;
+  padding-block: var(--size-3);
+  padding-inline: var(--size-6);
+  background-color: var(--color-accent);
+  color: #fff;
+  text-decoration: none;
+  border-radius: 8px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-block-start: var(--size-2);
+}
+
+.ticketLink:hover {
+  filter: brightness(1.1);
 }
 
 @media (min-width: 768px) {
   .content {
     padding: var(--size-8);
+    gap: var(--size-6);
   }
 
-  .header h1 {
-    font-size: var(--size-16);
-    text-align: left;
+  .body {
+    grid-template-columns: minmax(0, 22rem) 1fr;
+    gap: var(--size-8);
+    align-items: start;
   }
 }

--- a/components/shows/show-detail/show-content.tsx
+++ b/components/shows/show-detail/show-content.tsx
@@ -3,6 +3,7 @@ import classes from './show-content.module.css'
 
 export default function ShowContent({ show }: { show: ShowWithVenue }) {
   const readableDate = new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
     day: 'numeric',
     month: 'long',
     year: 'numeric',
@@ -14,15 +15,27 @@ export default function ShowContent({ show }: { show: ShowWithVenue }) {
       <header className={classes.header}>
         <h1>{show.title}</h1>
       </header>
-      <div className={classes.image}>
-        <img src={show.image} alt={show.title} />
-      </div>
-      <div className={classes.details}>
-        <p>{show.venue.name}</p>
-        <p>{show.time}</p>
-        <time>{readableDate}</time>
-        <p>${show.price}</p>
-        {show.excerpt && <p>{show.excerpt}</p>}
+      <div className={classes.body}>
+        <div className={classes.image}>
+          <img src={show.image} alt={show.title} />
+        </div>
+        <div className={classes.details}>
+          <p className={classes.venue}>{show.venue.name}</p>
+          <time>{readableDate}</time>
+          <p>{show.time}</p>
+          <p>{show.price}</p>
+          {show.excerpt && <p className={classes.excerpt}>{show.excerpt}</p>}
+          {show.ticketUrl && (
+            <a
+              href={show.ticketUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={classes.ticketLink}
+            >
+              Buy Tickets
+            </a>
+          )}
+        </div>
       </div>
     </article>
   )

--- a/lib/shows.ts
+++ b/lib/shows.ts
@@ -11,17 +11,26 @@ export async function getFeaturedShows(): Promise<ShowWithVenue[]> {
   return prisma.show.findMany({
     where: { isFeatured: true },
     orderBy: { rating: 'asc' },
-    take: 50,
+    take: 8,
     include: withVenue,
   })
 }
 
-export async function getAllShows(): Promise<ShowWithVenue[]> {
-  return prisma.show.findMany({
-    orderBy: { date: 'asc' },
-    take: 500,
-    include: withVenue,
-  })
+export const SHOWS_PER_PAGE = 12
+
+export async function getAllShows(
+  { page = 1, perPage = SHOWS_PER_PAGE }: { page?: number; perPage?: number } = {},
+): Promise<{ items: ShowWithVenue[]; total: number }> {
+  const [items, total] = await Promise.all([
+    prisma.show.findMany({
+      orderBy: { date: 'asc' },
+      skip: (page - 1) * perPage,
+      take: perPage,
+      include: withVenue,
+    }),
+    prisma.show.count(),
+  ])
+  return { items, total }
 }
 
 export async function getShowBySlug(slug: string): Promise<ShowWithVenue | null> {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "migrate:status": "prisma migrate status",
     "db:generate": "prisma generate",
     "db:studio": "prisma studio",
-    "scrape:broadway": "ts-node --project scrapers/tsconfig.json scrapers/venues/the-broadway.ts",
-    "scrape:broadway:dev": "INGEST_URL=http://localhost:3000/api/shows ts-node --project scrapers/tsconfig.json scrapers/venues/the-broadway.ts",
-    "scrape:broadway:prod": "INGEST_URL=https://distortnewyork.com/api/shows ts-node --project scrapers/tsconfig.json scrapers/venues/the-broadway.ts"
+    "scraper:broadway": "ts-node --project scrapers/tsconfig.json scrapers/venues/the-broadway.ts",
+    "scraper:tv-eye": "ts-node --project scrapers/tsconfig.json scrapers/venues/tv-eye.ts",
+    "test:broadway": "ts-node --project scrapers/tsconfig.json scrapers/test-broadway.ts",
+    "test:tv-eye": "ts-node --project scrapers/tsconfig.json scrapers/test-tv-eye.ts",
+    "db:clear": "ts-node --project scrapers/tsconfig.json scripts/db-clear.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",

--- a/prisma/migrations/20260419002442_add_ticket_url/migration.sql
+++ b/prisma/migrations/20260419002442_add_ticket_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Show" ADD COLUMN     "ticketUrl" TEXT NOT NULL DEFAULT '';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model Show {
   price      String
   image      String
   excerpt    String    @default("")
+  ticketUrl  String    @default("")
   rating     Int       @default(0)
   isFeatured Boolean   @default(false)
   createdAt  DateTime  @default(now())

--- a/scrapers/lib/env.ts
+++ b/scrapers/lib/env.ts
@@ -1,0 +1,5 @@
+import dotenv from 'dotenv'
+
+// dotenv/config only loads .env — Next.js projects keep secrets in .env.local
+dotenv.config({ path: '.env.local' })
+dotenv.config() // .env as fallback, won't override already-set vars

--- a/scrapers/lib/extract.ts
+++ b/scrapers/lib/extract.ts
@@ -1,30 +1,60 @@
 import Anthropic from '@anthropic-ai/sdk'
 import type { ScrapedShow } from './types'
 
+export function parseRawEvents(rawText: string): Map<string, { image: string; ticketUrl: string }> {
+  const map = new Map<string, { image: string; ticketUrl: string }>()
+  for (const e of rawText.split('\n\n---\n\n').filter(Boolean)) {
+    const slug = e.match(/^SLUG: (.+)$/m)?.[1]?.trim() ?? ''
+    const image = e.match(/^IMAGE: (.+)$/m)?.[1]?.trim() ?? ''
+    const ticketUrl = e.match(/^TICKET_URL: (.+)$/m)?.[1]?.trim() ?? ''
+    if (slug) map.set(slug, { image, ticketUrl })
+  }
+  return map
+}
+
 const client = new Anthropic()
 
-const BATCH_SIZE = 20
+const BATCH_SIZE = 10
 
-async function extractBatch(eventsText: string, venueName: string): Promise<ScrapedShow[]> {
+const EXTRACT_TOOL: Anthropic.Tool = {
+  name: 'ingest_shows',
+  description: 'Output structured show data extracted from the venue listing',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      shows: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            title:  { type: 'string' },
+            slug:   { type: 'string' },
+            date:   { type: 'string', description: 'ISO 8601, e.g. "2026-05-10T00:00:00.000Z"' },
+            time:   { type: 'string', description: 'e.g. "7:00 PM"' },
+            price:  { type: 'string', description: 'Use advance price if multiple listed. Always prefix numeric amounts with "$" (e.g. "$15.00"). Use "Free" if $0. Do not output a bare number.' },
+            genre:  { type: 'string', description: 'Infer from DETAILS if not provided, e.g. "punk", "experimental"' },
+            excerpt:   { type: 'string', description: 'Full description from DETAILS, preserving paragraph breaks as \\n\\n. If DETAILS is empty or missing, synthesize ONE short sentence from the other fields (title, genre, time, venue), e.g. "{title} — {genre} at {venue}, doors {time}".' },
+          },
+          required: ['title', 'slug', 'date', 'time', 'price', 'genre', 'excerpt'],
+        },
+      },
+    },
+    required: ['shows'],
+  },
+}
+
+async function extractBatch(eventsText: string, venueName: string): Promise<{ shows: ScrapedShow[]; stopReason: string | null }> {
   const message = await client.messages.create({
     model: 'claude-haiku-4-5-20251001',
     max_tokens: 8192,
+    tools: [EXTRACT_TOOL],
+    tool_choice: { type: 'tool', name: 'ingest_shows' },
     messages: [
       {
         role: 'user',
-        content: `Extract all shows from this venue listing. Each event is separated by "---". Return a JSON array only — no explanation, no markdown.
+        content: `Extract all shows from this venue listing. Each event is separated by "---".
 
 Venue: ${venueName}
-
-Each show object must have these exact fields:
-- title: string — band/show name
-- slug: string — use the SLUG value provided exactly as-is
-- date: string — ISO 8601 from the DATE field, e.g. "2026-05-10T00:00:00.000Z"
-- time: string — from the TIME field, e.g. "7:00 PM"
-- price: string — extract from DETAILS, e.g. "$15" or "Free". Use the advance price if multiple are listed.
-- genre: string — infer from band description in DETAILS, e.g. "punk", "rock", "experimental". Use your best judgment.
-- excerpt: string — 1-2 sentence description from DETAILS if available, otherwise ""
-- image: string — from the IMAGE field, use as-is
 
 Event data:
 ${eventsText}`,
@@ -32,9 +62,10 @@ ${eventsText}`,
     ],
   })
 
-  const raw = message.content[0].type === 'text' ? message.content[0].text : '[]'
-  const text = raw.replace(/^```(?:json)?\n?/m, '').replace(/\n?```$/m, '').trim()
-  return JSON.parse(text) as ScrapedShow[]
+  const toolUse = message.content.find((block) => block.type === 'tool_use')
+  if (!toolUse || toolUse.type !== 'tool_use') return { shows: [], stopReason: message.stop_reason ?? null }
+  const input = toolUse.input as { shows: ScrapedShow[] }
+  return { shows: input.shows ?? [], stopReason: message.stop_reason ?? null }
 }
 
 export async function extractShows(rawText: string, venueName: string): Promise<ScrapedShow[]> {
@@ -42,12 +73,18 @@ export async function extractShows(rawText: string, venueName: string): Promise<
   const results: ScrapedShow[] = []
 
   for (let i = 0; i < events.length; i += BATCH_SIZE) {
-    const batch = events.slice(i, i + BATCH_SIZE).join('\n\n---\n\n')
+    const batchNum = i / BATCH_SIZE + 1
+    const batchEvents = events.slice(i, i + BATCH_SIZE)
+    const batch = batchEvents.join('\n\n---\n\n')
     try {
-      const shows = await extractBatch(batch, venueName)
+      const { shows, stopReason } = await extractBatch(batch, venueName)
+      console.log(`  batch ${batchNum}: ${shows.length}/${batchEvents.length} shows (stop: ${stopReason})`)
+      if (stopReason === 'max_tokens') {
+        console.warn(`    ⚠ hit max_tokens — lower BATCH_SIZE or raise max_tokens`)
+      }
       results.push(...shows)
     } catch (err) {
-      console.error(`  ✗ Batch ${i / BATCH_SIZE + 1} failed:`, err)
+      console.error(`  ✗ Batch ${batchNum} failed:`, err)
     }
   }
 

--- a/scrapers/lib/ingest.ts
+++ b/scrapers/lib/ingest.ts
@@ -1,6 +1,6 @@
 import type { ScrapedShow, VenueConfig } from './types'
 
-const INGEST_URL = process.env.INGEST_URL!
+const INGEST_URL = process.env.INGEST_URL ?? 'https://distortnewyork.com/api/shows'
 const INGEST_SECRET = process.env.INGEST_SECRET!
 
 export async function ingestShow(show: ScrapedShow, venue: VenueConfig): Promise<void> {
@@ -24,5 +24,7 @@ export async function ingestShow(show: ScrapedShow, venue: VenueConfig): Promise
 
   if (!res.ok) {
     console.error(`  ✗ Failed to ingest "${show.title}": ${res.status}`)
+  } else {
+    console.log(`  ✓ "${show.title}"`)
   }
 }

--- a/scrapers/lib/types.ts
+++ b/scrapers/lib/types.ts
@@ -13,4 +13,5 @@ export type ScrapedShow = {
   genre: string
   excerpt: string
   image: string
+  ticketUrl?: string
 }

--- a/scrapers/run.ts
+++ b/scrapers/run.ts
@@ -1,12 +1,13 @@
-import 'dotenv/config'
+import './lib/env'
 import { venue as broadway, scrape as scrapeBroadway } from './venues/the-broadway'
+import { venue as tvEye, scrape as scrapeTvEye } from './venues/tv-eye'
 import { extractShows } from './lib/extract'
 import { ingestShow } from './lib/ingest'
 import type { VenueConfig } from './lib/types'
 
 const scrapers: { venue: VenueConfig; scrape: () => Promise<string> }[] = [
   { venue: broadway, scrape: scrapeBroadway },
-  // add new venues here
+  { venue: tvEye, scrape: scrapeTvEye },
 ]
 
 async function run() {

--- a/scrapers/test-broadway.ts
+++ b/scrapers/test-broadway.ts
@@ -1,0 +1,19 @@
+import './lib/env'
+
+process.env.SCRAPE_LIMIT = '6'
+
+import { venue, scrape } from './venues/the-broadway'
+import { extractShows } from './lib/extract'
+
+async function test() {
+  console.log(`Testing: ${venue.name}`)
+  const raw = await scrape()
+  console.log('\n--- RAW OUTPUT ---')
+  console.log(raw)
+  console.log('\n--- HAIKU EXTRACTION ---')
+  const shows = await extractShows(raw, venue.name)
+  console.log(JSON.stringify(shows, null, 2))
+  console.log(`\n✓ ${shows.length} shows extracted`)
+}
+
+test().catch(console.error)

--- a/scrapers/test-tv-eye.ts
+++ b/scrapers/test-tv-eye.ts
@@ -1,0 +1,19 @@
+import './lib/env'
+
+process.env.SCRAPE_LIMIT = '6'
+
+import { venue, scrape } from './venues/tv-eye'
+import { extractShows } from './lib/extract'
+
+async function test() {
+  console.log(`Testing: ${venue.name}`)
+  const raw = await scrape()
+  console.log('\n--- RAW OUTPUT ---')
+  console.log(raw)
+  console.log('\n--- HAIKU EXTRACTION ---')
+  const shows = await extractShows(raw, venue.name)
+  console.log(JSON.stringify(shows, null, 2))
+  console.log(`\n✓ ${shows.length} shows extracted`)
+}
+
+test().catch(console.error)

--- a/scrapers/test.ts
+++ b/scrapers/test.ts
@@ -1,16 +1,32 @@
-import 'dotenv/config'
-import { venue, scrape } from './venues/the-broadway'
+import './lib/env'
+
+process.env.SCRAPE_LIMIT = '6'
+
+import { venue as broadway, scrape as scrapeBroadway } from './venues/the-broadway'
+import { venue as tvEye, scrape as scrapeTvEye } from './venues/tv-eye'
 import { extractShows } from './lib/extract'
 
+const scrapers = [
+  { venue: broadway, scrape: scrapeBroadway },
+  { venue: tvEye, scrape: scrapeTvEye },
+]
+
 async function test() {
-  console.log(`Scraping ${venue.name}...`)
-  const raw = await scrape()
-  console.log('\n--- RAW OUTPUT (first 500 chars) ---')
-  console.log(raw.slice(0, 500))
-  console.log('\n--- EXTRACTING WITH HAIKU ---')
-  const shows = await extractShows(raw, venue.name)
-  console.log(JSON.stringify(shows, null, 2))
-  console.log(`\n✓ ${shows.length} shows extracted`)
+  for (const { venue, scrape } of scrapers) {
+    console.log(`\n${'='.repeat(60)}`)
+    console.log(`Testing: ${venue.name}`)
+    console.log('='.repeat(60))
+
+    const raw = await scrape()
+
+    console.log('\n--- RAW OUTPUT ---')
+    console.log(raw)
+
+    console.log('\n--- HAIKU EXTRACTION ---')
+    const shows = await extractShows(raw, venue.name)
+    console.log(JSON.stringify(shows, null, 2))
+    console.log(`\n✓ ${shows.length} shows extracted`)
+  }
 }
 
 test().catch(console.error)

--- a/scrapers/venues/the-broadway.ts
+++ b/scrapers/venues/the-broadway.ts
@@ -1,6 +1,6 @@
-import 'dotenv/config'
+import '../lib/env'
 import { chromium } from 'playwright'
-import { extractShows } from '../lib/extract'
+import { extractShows, parseRawEvents } from '../lib/extract'
 import { ingestShow } from '../lib/ingest'
 import type { VenueConfig } from '../lib/types'
 
@@ -15,26 +15,54 @@ export async function scrape(): Promise<string> {
   const page = await browser.newPage()
   await page.goto(venue.url, { waitUntil: 'networkidle' })
 
-  const events = await page.$$eval('.eventlist-column-info', (nodes) =>
+  const rawCards = await page.$$eval('.eventlist-column-info', (nodes) =>
     nodes.map((node) => {
       const titleEl = node.querySelector('.eventlist-title-link')
       const title = titleEl?.textContent?.trim() ?? ''
-
-      // Extract slug directly from Squarespace URL — e.g. /showcalendar/band-name-slug → band-name-slug
       const href = titleEl?.getAttribute('href') ?? ''
       const slug = href.split('/').filter(Boolean).pop() ?? ''
-
       const date = node.querySelector('time.event-date')?.getAttribute('datetime') ?? ''
       const time = node.querySelector('time.event-time-localized-start')?.textContent?.trim() ?? ''
-      const image = node.querySelector('img[data-src]')?.getAttribute('data-src') ?? ''
-      const bodyText = Array.from(node.querySelectorAll('.sqs-html-content p, .sqs-html-content h3'))
-        .map((el) => el.textContent?.trim())
-        .filter(Boolean)
-        .join('\n')
-
-      return `TITLE: ${title}\nSLUG: ${slug}\nDATE: ${date}\nTIME: ${time}\nIMAGE: ${image}\nDETAILS:\n${bodyText}`
+      return { title, slug, href, date, time }
     })
   )
+
+  const cutoff = new Date()
+  cutoff.setMonth(cutoff.getMonth() + 3)
+  const withinWindow = rawCards.filter((c) => c.date && new Date(c.date) <= cutoff)
+
+  const limit = process.env.SCRAPE_LIMIT ? parseInt(process.env.SCRAPE_LIMIT) : Infinity
+  const toProcess = withinWindow.slice(0, limit)
+
+  // Visit each event detail page for the image and full description
+  // Broadway uses multiple .sqs-html-content blocks — collect all, join in order
+  const events: string[] = []
+  for (const card of toProcess) {
+    const detailUrl = `https://www.thebroadway.nyc${card.href}`
+    const detailPage = await browser.newPage()
+    try {
+      await detailPage.goto(detailUrl, { waitUntil: 'domcontentloaded' })
+      const { image, description } = await detailPage.evaluate(() => {
+        const blocks = Array.from(
+          document.querySelectorAll('.eventitem-column-content [data-sqsp-block="text"] .sqs-html-content')
+        )
+        const description = blocks
+          .map((el) => (el as HTMLElement).innerText?.trim())
+          .filter(Boolean)
+          .join('\n\n')
+        const image =
+          document.querySelector('.sqs-block-image img[data-src]')?.getAttribute('data-src') ?? ''
+        return { image, description }
+      })
+      events.push(
+        `TITLE: ${card.title}\nSLUG: ${card.slug}\nDATE: ${card.date}\nTIME: ${card.time}\nIMAGE: ${image}\nDETAILS:\n${description}`
+      )
+    } catch (err) {
+      console.error(`  ✗ Failed to load detail page for "${card.title}":`, err)
+    } finally {
+      await detailPage.close()
+    }
+  }
 
   await browser.close()
   return events.join('\n\n---\n\n')
@@ -43,11 +71,19 @@ export async function scrape(): Promise<string> {
 async function run() {
   console.log(`Scraping ${venue.name}...`)
   const raw = await scrape()
+  const bySlug = parseRawEvents(raw)
   const shows = await extractShows(raw, venue.name)
   for (const show of shows) {
+    const scraped = bySlug.get(show.slug)
+    if (scraped) {
+      show.image = scraped.image
+      show.ticketUrl = scraped.ticketUrl
+    }
     await ingestShow(show, venue)
   }
   console.log(`✓ ${shows.length} shows ingested`)
 }
 
-run().catch(console.error)
+if (require.main === module) {
+  run().catch(console.error)
+}

--- a/scrapers/venues/tv-eye.ts
+++ b/scrapers/venues/tv-eye.ts
@@ -1,0 +1,145 @@
+import '../lib/env'
+import { chromium } from 'playwright'
+import { extractShows, parseRawEvents } from '../lib/extract'
+import { ingestShow } from '../lib/ingest'
+import type { VenueConfig } from '../lib/types'
+
+export const venue: VenueConfig = {
+  name: 'TV Eye',
+  slug: 'tv-eye',
+  url: 'https://tveyenyc.com/calendar/',
+}
+
+const MONTH_MAP: Record<string, number> = {
+  Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5,
+  Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11,
+}
+
+// TV Eye's See Tickets widget sometimes embeds a broken bucket (prod-sph)
+// inside the base64 payload — swap to the working bucket (prod-sih).
+function fixSeeTicketsImage(url: string): string {
+  const match = url.match(/^(https:\/\/prod-images\.seetickets\.us\/)([A-Za-z0-9+/=]+)$/)
+  if (!match) return url
+  try {
+    const decoded = Buffer.from(match[2], 'base64').toString('utf-8')
+    if (!decoded.includes('prod-sph.seeticketsusa.us')) return url
+    const fixed = decoded.replace('prod-sph.seeticketsusa.us', 'prod-sih.seeticketsusa.us')
+    return match[1] + Buffer.from(fixed, 'utf-8').toString('base64')
+  } catch {
+    return url
+  }
+}
+
+function toISO(dateStr: string): string {
+  const parts = dateStr.trim().split(/\s+/)
+  if (parts.length < 3) return ''
+  const month = MONTH_MAP[parts[1]] ?? -1
+  const day = parseInt(parts[2], 10)
+  if (month === -1 || isNaN(day)) return ''
+  const now = new Date()
+  const year =
+    month < now.getMonth() || (month === now.getMonth() && day < now.getDate())
+      ? now.getFullYear() + 1
+      : now.getFullYear()
+  return new Date(Date.UTC(year, month, day)).toISOString()
+}
+
+export async function scrape(): Promise<string> {
+  const browser = await chromium.launch()
+  const context = await browser.newContext({
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  })
+  const page = await context.newPage()
+  await page.goto(venue.url, { waitUntil: 'networkidle' })
+
+  async function collectCards() {
+    return page.$$eval('.seetickets-list-event-container', (cards) =>
+      cards.map((card) => {
+        const info = card.querySelector('.event-info-block')
+        const titleEl = info?.querySelector('p.title a')
+        const href = titleEl?.getAttribute('href') ?? ''
+        const slug = href.split('/event/')[1]?.split('/')[0] ?? ''
+        const rawImage = card.querySelector('img')?.getAttribute('src') ?? ''
+        return {
+          title: titleEl?.textContent?.trim() ?? '',
+          slug,
+          dateText: info?.querySelector('p.date')?.textContent?.trim() ?? '',
+          time: info?.querySelector('.see-showtime')?.textContent?.trim() ?? '',
+          price: info?.querySelector('span.price')?.textContent?.trim() ?? '',
+          genre: info?.querySelector('p.genre')?.textContent?.trim() ?? '',
+          ticketUrl: href,
+          image: rawImage,
+        }
+      })
+    )
+  }
+
+  const pageNumbers = await page.$$eval(
+    '.seetickets-list-view-pagination li[data-see-ajax-page]',
+    (lis) => lis.map((li) => parseInt(li.getAttribute('data-see-ajax-page') ?? '0', 10)).filter((n) => n > 0)
+  )
+  const allPages = [1, ...pageNumbers.filter((n) => n !== 1)].sort((a, b) => a - b)
+  console.log(`TV Eye: ${allPages.length} pages (${allPages.join(', ')})`)
+
+  const bySlug = new Map<string, Awaited<ReturnType<typeof collectCards>>[number]>()
+  for (const n of allPages) {
+    if (n > 1) {
+      const firstSlug = (await collectCards())[0]?.slug ?? ''
+      await page.locator(`.seetickets-list-view-pagination li[data-see-ajax-page="${n}"]`).click()
+      await page.waitForFunction(
+        (prev) => {
+          const first = document.querySelector('.seetickets-list-event-container .event-info-block p.title a')
+          const href = first?.getAttribute('href') ?? ''
+          const slug = href.split('/event/')[1]?.split('/')[0] ?? ''
+          return slug && slug !== prev
+        },
+        firstSlug,
+        { timeout: 15000 }
+      )
+    }
+    const cards = await collectCards()
+    for (const c of cards) if (c.slug) bySlug.set(c.slug, c)
+    console.log(`  page ${n}: +${cards.length} cards (total unique: ${bySlug.size})`)
+  }
+
+  const rawCards = Array.from(bySlug.values()).map((c) => ({ ...c, image: fixSeeTicketsImage(c.image) }))
+
+  const cutoff = new Date()
+  cutoff.setMonth(cutoff.getMonth() + 3)
+
+  const filtered = rawCards
+    .map((c) => ({ ...c, date: toISO(c.dateText) }))
+    .filter((c) => c.date && new Date(c.date) <= cutoff)
+
+  const limit = process.env.SCRAPE_LIMIT ? parseInt(process.env.SCRAPE_LIMIT) : Infinity
+  const toProcess = filtered.slice(0, limit)
+
+  await context.close()
+  await browser.close()
+
+  return toProcess
+    .map((c) =>
+      `TITLE: ${c.title}\nSLUG: ${c.slug}\nDATE: ${c.date}\nTIME: ${c.time}\nPRICE: ${c.price}\nGENRE: ${c.genre}\nIMAGE: ${c.image}\nTICKET_URL: ${c.ticketUrl}\nDETAILS:`
+    )
+    .join('\n\n---\n\n')
+}
+
+async function run() {
+  console.log(`Scraping ${venue.name}...`)
+  const raw = await scrape()
+  const bySlug = parseRawEvents(raw)
+  const shows = await extractShows(raw, venue.name)
+  for (const show of shows) {
+    const scraped = bySlug.get(show.slug)
+    if (scraped) {
+      show.image = scraped.image
+      show.ticketUrl = scraped.ticketUrl
+    }
+    await ingestShow(show, venue)
+  }
+  console.log(`✓ ${shows.length} shows ingested`)
+}
+
+if (require.main === module) {
+  run().catch(console.error)
+}

--- a/scripts/db-clear.ts
+++ b/scripts/db-clear.ts
@@ -1,0 +1,47 @@
+import '../scrapers/lib/env'
+import { neon } from '@neondatabase/serverless'
+
+const sql = neon(process.env.DATABASE_URL!)
+
+function usage(): never {
+  console.error(`Usage:
+  npm run db:clear -- <venue-slug>              delete all shows for a venue
+  npm run db:clear -- <venue-slug> --with-venue delete shows + venue
+  npm run db:clear -- --all                     delete ALL shows and ALL venues`)
+  process.exit(1)
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  if (args.length === 0) usage()
+
+  if (args.includes('--all')) {
+    const shows = await sql`DELETE FROM "Show"` as unknown as { rowCount: number }
+    const venues = await sql`DELETE FROM "Venue"` as unknown as { rowCount: number }
+    console.log(`✓ Deleted ${shows.rowCount ?? 0} shows and ${venues.rowCount ?? 0} venues`)
+    return
+  }
+
+  const slug = args.find((a) => !a.startsWith('--'))
+  if (!slug) usage()
+
+  const venues = (await sql`SELECT id, name FROM "Venue" WHERE slug = ${slug}`) as Array<{ id: string; name: string }>
+  if (venues.length === 0) {
+    console.error(`✗ No venue found with slug "${slug}"`)
+    process.exit(1)
+  }
+  const venue = venues[0]
+
+  const shows = (await sql`DELETE FROM "Show" WHERE "venueId" = ${venue.id}`) as unknown as { rowCount: number }
+  console.log(`✓ Deleted ${shows.rowCount ?? 0} shows for "${venue.name}"`)
+
+  if (args.includes('--with-venue')) {
+    await sql`DELETE FROM "Venue" WHERE id = ${venue.id}`
+    console.log(`✓ Deleted venue "${venue.name}"`)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/delete-past-shows",
+      "schedule": "0 9 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
  - Add TV Eye scraper with paginated list view and slug-based dedup
  - Add ticketUrl field to Show + Buy Tickets link on detail page
  - Stitch image/ticketUrl back from raw scrape to avoid Haiku mangling base64 URLs
  - Lower Haiku batch size to 10 to prevent silent max_tokens truncation
  - Filter both scrapers to shows within 3 months
  - Add numbered pagination to /shows (12 per page) with shareable ?page= URL
  - Redesign show detail page with two-column grid on desktop, mobile-first
  - Cap homepage featured shows at 8 (no pager, cleaner landing)
  - Add Vercel cron to delete past shows daily at 9am UTC (~4am NY)
  - Add db:clear script for wiping venues/shows during dev
  - Rename scrape:* npm scripts to scraper:*