### PR TITLE
feat: admin shows list with filters + featured toggle

### DIFF
--- a/actions/admin/shows.ts
+++ b/actions/admin/shows.ts
@@ -1,0 +1,18 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import prisma from '@/lib/prisma'
+
+export async function toggleFeaturedAction(formData: FormData): Promise<void> {
+  const id = String(formData.get('id') ?? '')
+  const next = formData.get('next') === 'true'
+  if (!id) return
+
+  await prisma.show.update({
+    where: { id },
+    data: { isFeatured: next },
+  })
+
+  revalidatePath('/admin/shows')
+  revalidatePath('/')
+}

--- a/app/admin/dashboard.module.css
+++ b/app/admin/dashboard.module.css
@@ -11,8 +11,23 @@
   color: var(--color-text);
 }
 
-.hint {
-  color: var(--color-text-secondary);
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--size-2);
+}
+
+.navLink {
+  padding: var(--size-2) var(--size-4);
+  background-color: var(--color-bg-elevated);
+  border: 1px solid var(--color-separator);
+  border-radius: 6px;
+  color: var(--color-text);
+}
+
+.navLink:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .signOut {

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { logoutAction } from '@/actions/admin/auth'
 import classes from './dashboard.module.css'
 
@@ -5,7 +6,9 @@ export default function AdminDashboardPage() {
   return (
     <section className={classes.wrap}>
       <h1 className={classes.title}>You&apos;re in</h1>
-      <p className={classes.hint}>Admin dashboard content comes next.</p>
+      <nav className={classes.nav}>
+        <Link href="/admin/shows" className={classes.navLink}>Manage shows</Link>
+      </nav>
       <form action={logoutAction}>
         <button type="submit" className={classes.signOut}>Sign out</button>
       </form>

--- a/app/admin/shows/error.tsx
+++ b/app/admin/shows/error.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export default function Error({ reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="center">
+      <p>Something went wrong loading shows.</p>
+      <button onClick={reset}>Try again</button>
+    </div>
+  )
+}

--- a/app/admin/shows/loading.tsx
+++ b/app/admin/shows/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div className="center"><p>Loading shows...</p></div>
+}

--- a/app/admin/shows/page.tsx
+++ b/app/admin/shows/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next'
+import { getAllVenues, getShowsForAdmin, ADMIN_SHOWS_PER_PAGE } from '@/lib/shows'
+import {
+  parseAdminShowsParams,
+  type AdminShowsSearchParams,
+} from '@/lib/admin/show-filters'
+import FilterPanel from '@/components/admin/filter-panel'
+import ShowTable from '@/components/admin/show-table'
+import AdminPagination from '@/components/admin/pagination'
+import classes from './shows.module.css'
+
+export const metadata: Metadata = {
+  title: 'Admin — Shows',
+  robots: { index: false, follow: false },
+}
+
+type Props = { searchParams: Promise<AdminShowsSearchParams> }
+
+export default async function AdminShowsPage({ searchParams }: Props) {
+  const sp = await searchParams
+  const { filters, page } = parseAdminShowsParams(sp)
+
+  const [{ items, total }, venues] = await Promise.all([
+    getShowsForAdmin(filters, { page }),
+    getAllVenues(),
+  ])
+
+  const totalPages = Math.max(1, Math.ceil(total / ADMIN_SHOWS_PER_PAGE))
+  const currentSearch = new URLSearchParams()
+  for (const [k, v] of Object.entries(sp)) {
+    if (v == null) continue
+    if (Array.isArray(v)) v.forEach(x => currentSearch.append(k, x))
+    else currentSearch.set(k, v)
+  }
+
+  return (
+    <section className={classes.page}>
+      <header className={classes.header}>
+        <h1 className={classes.title}>Shows</h1>
+        <p className={classes.count}>
+          {total.toLocaleString()} result{total === 1 ? '' : 's'}
+        </p>
+      </header>
+
+      <div className={classes.layout}>
+        <FilterPanel venues={venues} />
+        <div className={classes.results}>
+          <ShowTable items={items} />
+          <AdminPagination
+            currentPage={page}
+            totalPages={totalPages}
+            basePath="/admin/shows"
+            searchParams={currentSearch}
+          />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/admin/shows/shows.module.css
+++ b/app/admin/shows/shows.module.css
@@ -1,0 +1,42 @@
+.page {
+  display: grid;
+  gap: var(--size-4);
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--size-3);
+}
+
+.title {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: var(--size-8);
+  color: var(--color-text);
+}
+
+.count {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.layout {
+  display: grid;
+  gap: var(--size-4);
+}
+
+.results {
+  display: grid;
+  gap: var(--size-2);
+  min-inline-size: 0;
+}
+
+@media (min-width: 1024px) {
+  .layout {
+    grid-template-columns: 18rem minmax(0, 1fr);
+    align-items: start;
+  }
+}

--- a/components/admin/filter-panel.module.css
+++ b/components/admin/filter-panel.module.css
@@ -1,0 +1,108 @@
+.panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--size-4);
+  padding: var(--size-4);
+  background-color: var(--color-bg-elevated);
+  border: 1px solid var(--color-separator);
+  border-radius: 8px;
+  min-inline-size: 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--size-3);
+}
+
+.heading {
+  margin: 0;
+  font-size: var(--size-5);
+  text-transform: uppercase;
+  color: var(--color-text);
+}
+
+.clear {
+  padding: var(--size-1) var(--size-3);
+  background-color: transparent;
+  border: 1px solid var(--color-separator);
+  border-radius: 6px;
+  color: var(--color-text-secondary);
+  font-size: var(--size-3);
+}
+
+.clear:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-secondary);
+}
+
+.group {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--size-2);
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-inline-size: 0;
+}
+
+.label {
+  font-size: var(--size-3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary);
+}
+
+.input {
+  font: inherit;
+  font-size: var(--size-4);
+  padding: var(--size-2) var(--size-3);
+  border: 1px solid var(--color-separator);
+  border-radius: 6px;
+  background-color: var(--color-bg-elevated-2);
+  color: var(--color-text);
+  inline-size: 100%;
+  min-inline-size: 0;
+  max-inline-size: 100%;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--size-2);
+}
+
+.checkList {
+  display: grid;
+  gap: var(--size-2);
+  max-block-size: 12rem;
+  overflow-y: auto;
+}
+
+.check {
+  display: flex;
+  align-items: center;
+  gap: var(--size-2);
+  font-size: var(--size-4);
+  color: var(--color-text);
+}
+
+.triRow {
+  display: grid;
+  gap: var(--size-2);
+}
+
+.tri {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: center;
+  gap: var(--size-2);
+  font-size: var(--size-4);
+  color: var(--color-text);
+}

--- a/components/admin/filter-panel.tsx
+++ b/components/admin/filter-panel.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react'
+import type { Venue } from '@/lib/shows'
+import classes from './filter-panel.module.css'
+
+type Props = { venues: Venue[] }
+
+type TextKey = 'q' | 'date_from' | 'date_to'
+const TEXT_KEYS: TextKey[] = ['q', 'date_from', 'date_to']
+
+export default function FilterPanel({ venues }: Props) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [, startTransition] = useTransition()
+
+  const initialText = useMemo(() => {
+    const obj = {} as Record<TextKey, string>
+    for (const k of TEXT_KEYS) obj[k] = searchParams.get(k) ?? ''
+    return obj
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+  const [text, setText] = useState(initialText)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const currentVenueSlugs = useMemo(() => {
+    const raw = searchParams.get('venue')
+    return raw ? raw.split(',').filter(Boolean) : []
+  }, [searchParams])
+
+  const featured = searchParams.get('featured') ?? ''
+
+  function push(next: URLSearchParams) {
+    next.delete('page')
+    const qs = next.toString()
+    startTransition(() => {
+      router.push(qs ? `${pathname}?${qs}` : pathname)
+    })
+  }
+
+  function setParam(key: string, value: string | null) {
+    const next = new URLSearchParams(searchParams.toString())
+    if (value == null || value === '') next.delete(key)
+    else next.set(key, value)
+    push(next)
+  }
+
+  function onTextChange(key: TextKey, value: string) {
+    setText(prev => ({ ...prev, [key]: value }))
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => setParam(key, value || null), 250)
+  }
+
+  function toggleVenue(slug: string) {
+    const set = new Set(currentVenueSlugs)
+    if (set.has(slug)) set.delete(slug)
+    else set.add(slug)
+    const list = Array.from(set)
+    setParam('venue', list.length ? list.join(',') : null)
+  }
+
+  function clearAll() {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    setText(Object.fromEntries(TEXT_KEYS.map(k => [k, ''])) as Record<TextKey, string>)
+    push(new URLSearchParams())
+  }
+
+  useEffect(() => () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+  }, [])
+
+  return (
+    <aside className={classes.panel}>
+      <div className={classes.header}>
+        <h2 className={classes.heading}>Filters</h2>
+        <button type="button" className={classes.clear} onClick={clearAll}>Clear</button>
+      </div>
+
+      <div className={classes.group}>
+        <label className={classes.label} htmlFor="f-q">Search</label>
+        <input
+          id="f-q"
+          className={classes.input}
+          type="text"
+          placeholder="title, excerpt, genre"
+          value={text.q}
+          onChange={e => onTextChange('q', e.target.value)}
+        />
+      </div>
+
+      <fieldset className={classes.group}>
+        <legend className={classes.label}>Venue</legend>
+        <div className={classes.checkList}>
+          {venues.map(v => (
+            <label key={v.id} className={classes.check}>
+              <input
+                type="checkbox"
+                checked={currentVenueSlugs.includes(v.slug)}
+                onChange={() => toggleVenue(v.slug)}
+              />
+              <span>{v.name}</span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <div className={classes.group}>
+        <label className={classes.label}>Date range</label>
+        <div className={classes.row}>
+          <input
+            className={classes.input}
+            type="date"
+            aria-label="From"
+            value={text.date_from}
+            onChange={e => onTextChange('date_from', e.target.value)}
+          />
+          <input
+            className={classes.input}
+            type="date"
+            aria-label="To"
+            value={text.date_to}
+            onChange={e => onTextChange('date_to', e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className={classes.group}>
+        <label className={classes.label} htmlFor="f-featured">Featured</label>
+        <select
+          id="f-featured"
+          className={classes.input}
+          value={featured}
+          onChange={e => setParam('featured', e.target.value || null)}
+        >
+          <option value="">Any</option>
+          <option value="true">Featured</option>
+          <option value="false">Not featured</option>
+        </select>
+      </div>
+    </aside>
+  )
+}

--- a/components/admin/pagination.module.css
+++ b/components/admin/pagination.module.css
@@ -1,0 +1,54 @@
+.pagination {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--size-2);
+  margin-block: var(--size-6);
+}
+
+.pages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  gap: var(--size-1);
+}
+
+.page,
+.active,
+.nav {
+  display: inline-grid;
+  place-items: center;
+  min-inline-size: 2.25rem;
+  block-size: 2.25rem;
+  padding-inline: var(--size-3);
+  border-radius: 0.5rem;
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.page:hover,
+.nav:hover {
+  background-color: var(--color-fill);
+  color: var(--color-text);
+}
+
+.active {
+  background-color: var(--color-accent);
+  color: #fff;
+  pointer-events: none;
+}
+
+.nav[aria-disabled='true'] {
+  color: var(--color-text-tertiary);
+  pointer-events: none;
+}
+
+.ellipsis {
+  display: inline-grid;
+  place-items: center;
+  min-inline-size: 2.25rem;
+  color: var(--color-text-tertiary);
+}

--- a/components/admin/pagination.tsx
+++ b/components/admin/pagination.tsx
@@ -1,0 +1,82 @@
+import Link from 'next/link'
+import classes from './pagination.module.css'
+
+type Props = {
+  currentPage: number
+  totalPages: number
+  basePath: string
+  searchParams: URLSearchParams
+}
+
+function pageList(current: number, total: number): (number | 'ellipsis')[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1)
+  const pages: (number | 'ellipsis')[] = [1]
+  const start = Math.max(2, current - 1)
+  const end = Math.min(total - 1, current + 1)
+  if (start > 2) pages.push('ellipsis')
+  for (let i = start; i <= end; i++) pages.push(i)
+  if (end < total - 1) pages.push('ellipsis')
+  pages.push(total)
+  return pages
+}
+
+export default function AdminPagination({
+  currentPage,
+  totalPages,
+  basePath,
+  searchParams,
+}: Props) {
+  if (totalPages <= 1) return null
+
+  function hrefFor(page: number): string {
+    const next = new URLSearchParams(searchParams)
+    if (page === 1) next.delete('page')
+    else next.set('page', String(page))
+    const qs = next.toString()
+    return qs ? `${basePath}?${qs}` : basePath
+  }
+
+  const pages = pageList(currentPage, totalPages)
+  const prevPage = Math.max(1, currentPage - 1)
+  const nextPage = Math.min(totalPages, currentPage + 1)
+
+  return (
+    <nav className={classes.pagination} aria-label="Pagination">
+      <Link
+        href={hrefFor(prevPage)}
+        className={classes.nav}
+        aria-label="Previous page"
+        aria-disabled={currentPage === 1}
+        tabIndex={currentPage === 1 ? -1 : undefined}
+      >
+        ‹
+      </Link>
+      <ul className={classes.pages}>
+        {pages.map((p, i) =>
+          p === 'ellipsis' ? (
+            <li key={`e${i}`} className={classes.ellipsis} aria-hidden>…</li>
+          ) : (
+            <li key={p}>
+              <Link
+                href={hrefFor(p)}
+                className={p === currentPage ? classes.active : classes.page}
+                aria-current={p === currentPage ? 'page' : undefined}
+              >
+                {p}
+              </Link>
+            </li>
+          ),
+        )}
+      </ul>
+      <Link
+        href={hrefFor(nextPage)}
+        className={classes.nav}
+        aria-label="Next page"
+        aria-disabled={currentPage === totalPages}
+        tabIndex={currentPage === totalPages ? -1 : undefined}
+      >
+        ›
+      </Link>
+    </nav>
+  )
+}

--- a/components/admin/show-table.module.css
+++ b/components/admin/show-table.module.css
@@ -1,0 +1,111 @@
+.wrap {
+  overflow-x: auto;
+  border: 1px solid var(--color-separator);
+  border-radius: 8px;
+  background-color: var(--color-bg-elevated);
+}
+
+.table {
+  inline-size: 100%;
+  border-collapse: collapse;
+  font-size: var(--size-4);
+  color: var(--color-text);
+}
+
+.table thead th {
+  position: sticky;
+  inset-block-start: 0;
+  padding: var(--size-3);
+  text-align: start;
+  font-size: var(--size-3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary);
+  background-color: var(--color-bg-elevated);
+  border-block-end: 1px solid var(--color-separator);
+  white-space: nowrap;
+}
+
+.table tbody tr {
+  border-block-end: 1px solid var(--color-separator);
+}
+
+.table tbody tr:nth-child(even) {
+  background-color: var(--color-bg-elevated-2);
+}
+
+.table tbody tr:last-child {
+  border-block-end: 0;
+}
+
+.table td {
+  padding: var(--size-3);
+  vertical-align: middle;
+}
+
+.table td:nth-child(2) {
+  white-space: nowrap;
+}
+
+.title a {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.title a:hover {
+  color: var(--color-accent);
+}
+
+.num {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.center {
+  text-align: center;
+}
+
+.starOn,
+.starOff {
+  display: inline-grid;
+  place-items: center;
+  inline-size: 2rem;
+  block-size: 2rem;
+  padding: 0;
+  font-size: var(--size-5);
+  line-height: 1;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+}
+
+.starOn {
+  color: var(--color-accent);
+}
+
+.starOff {
+  color: var(--color-text-tertiary);
+}
+
+.starOn:hover,
+.starOff:hover {
+  background-color: var(--color-fill);
+}
+
+.action {
+  color: var(--color-accent);
+}
+
+.action:hover {
+  text-decoration: underline;
+}
+
+.empty {
+  padding: var(--size-6);
+  margin: 0;
+  text-align: center;
+  color: var(--color-text-secondary);
+  background-color: var(--color-bg-elevated);
+  border: 1px solid var(--color-separator);
+  border-radius: 8px;
+}

--- a/components/admin/show-table.tsx
+++ b/components/admin/show-table.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link'
+import { toggleFeaturedAction } from '@/actions/admin/shows'
+import type { ShowWithVenue } from '@/lib/shows'
+import classes from './show-table.module.css'
+
+type Props = { items: ShowWithVenue[] }
+
+const dateFmt = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/New_York',
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
+})
+
+export default function ShowTable({ items }: Props) {
+  if (items.length === 0) {
+    return <p className={classes.empty}>No shows match these filters.</p>
+  }
+  return (
+    <div className={classes.wrap}>
+      <table className={classes.table}>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Venue</th>
+            <th>Date</th>
+            <th>Genre</th>
+            <th aria-label="Featured">★</th>
+            <th>Rating</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(show => (
+            <tr key={show.id}>
+              <td className={classes.title}>
+                <Link href={`/admin/shows/${show.id}`}>{show.title}</Link>
+              </td>
+              <td>{show.venue.name}</td>
+              <td className={classes.num}>{dateFmt.format(show.date)}</td>
+              <td>{show.genre}</td>
+              <td className={classes.center}>
+                <form action={toggleFeaturedAction}>
+                  <input type="hidden" name="id" value={show.id} />
+                  <input type="hidden" name="next" value={String(!show.isFeatured)} />
+                  <button
+                    type="submit"
+                    className={show.isFeatured ? classes.starOn : classes.starOff}
+                    aria-label={show.isFeatured ? 'Unfeature' : 'Feature'}
+                    title={show.isFeatured ? 'Unfeature' : 'Feature'}
+                  >
+                    {show.isFeatured ? '★' : '☆'}
+                  </button>
+                </form>
+              </td>
+              <td className={classes.num}>{show.rating}</td>
+              <td>
+                <Link href={`/admin/shows/${show.id}`} className={classes.action}>Edit</Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/lib/admin/show-filters.ts
+++ b/lib/admin/show-filters.ts
@@ -1,0 +1,65 @@
+import type { AdminShowFilters } from '@/lib/shows'
+
+export type AdminShowsSearchParams = {
+  q?: string
+  title?: string
+  slug?: string
+  venue?: string | string[]
+  genre?: string
+  date_from?: string
+  date_to?: string
+  featured?: string
+  rating_min?: string
+  rating_max?: string
+  has_image?: string
+  has_ticket?: string
+  has_excerpt?: string
+  page?: string
+}
+
+function asString(v: string | string[] | undefined): string | undefined {
+  if (Array.isArray(v)) return v[0]
+  return v
+}
+
+function asTriBool(v: string | undefined): boolean | undefined {
+  if (v === 'true') return true
+  if (v === 'false') return false
+  return undefined
+}
+
+function asNumber(v: string | undefined): number | undefined {
+  if (!v) return undefined
+  const n = Number(v)
+  return Number.isFinite(n) ? n : undefined
+}
+
+function asVenueSlugs(v: string | string[] | undefined): string[] | undefined {
+  if (!v) return undefined
+  const raw = Array.isArray(v) ? v.join(',') : v
+  const parts = raw.split(',').map(s => s.trim()).filter(Boolean)
+  return parts.length ? parts : undefined
+}
+
+export function parseAdminShowsParams(sp: AdminShowsSearchParams): {
+  filters: AdminShowFilters
+  page: number
+} {
+  const filters: AdminShowFilters = {
+    q: asString(sp.q) || undefined,
+    title: asString(sp.title) || undefined,
+    slug: asString(sp.slug) || undefined,
+    venueSlugs: asVenueSlugs(sp.venue),
+    genre: asString(sp.genre) || undefined,
+    dateFrom: asString(sp.date_from) || undefined,
+    dateTo: asString(sp.date_to) || undefined,
+    isFeatured: asTriBool(asString(sp.featured)),
+    ratingMin: asNumber(asString(sp.rating_min)),
+    ratingMax: asNumber(asString(sp.rating_max)),
+    hasImage: asTriBool(asString(sp.has_image)),
+    hasTicketUrl: asTriBool(asString(sp.has_ticket)),
+    hasExcerpt: asTriBool(asString(sp.has_excerpt)),
+  }
+  const page = Math.max(1, asNumber(asString(sp.page)) ?? 1)
+  return { filters, page }
+}

--- a/lib/shows.ts
+++ b/lib/shows.ts
@@ -88,6 +88,85 @@ export async function getVenueBySlug(slug: string) {
   })
 }
 
+export const ADMIN_SHOWS_PER_PAGE = 25
+
+export type AdminShowFilters = {
+  q?: string
+  title?: string
+  slug?: string
+  venueSlugs?: string[]
+  genre?: string
+  dateFrom?: string
+  dateTo?: string
+  isFeatured?: boolean
+  ratingMin?: number
+  ratingMax?: number
+  hasImage?: boolean
+  hasTicketUrl?: boolean
+  hasExcerpt?: boolean
+}
+
+function buildAdminWhere(f: AdminShowFilters) {
+  const AND: Record<string, unknown>[] = []
+
+  if (f.q) {
+    AND.push({
+      OR: [
+        { title: { contains: f.q, mode: 'insensitive' } },
+        { excerpt: { contains: f.q, mode: 'insensitive' } },
+        { genre: { contains: f.q, mode: 'insensitive' } },
+      ],
+    })
+  }
+  if (f.title) AND.push({ title: { contains: f.title, mode: 'insensitive' } })
+  if (f.slug) AND.push({ slug: { contains: f.slug, mode: 'insensitive' } })
+  if (f.genre) AND.push({ genre: { contains: f.genre, mode: 'insensitive' } })
+  if (f.venueSlugs?.length) AND.push({ venue: { slug: { in: f.venueSlugs } } })
+
+  if (f.dateFrom || f.dateTo) {
+    const range: Record<string, Date> = {}
+    if (f.dateFrom) range.gte = new Date(`${f.dateFrom}T00:00:00.000Z`)
+    if (f.dateTo) range.lte = new Date(`${f.dateTo}T23:59:59.999Z`)
+    AND.push({ date: range })
+  }
+
+  if (typeof f.isFeatured === 'boolean') AND.push({ isFeatured: f.isFeatured })
+
+  if (typeof f.ratingMin === 'number' || typeof f.ratingMax === 'number') {
+    const range: Record<string, number> = {}
+    if (typeof f.ratingMin === 'number') range.gte = f.ratingMin
+    if (typeof f.ratingMax === 'number') range.lte = f.ratingMax
+    AND.push({ rating: range })
+  }
+
+  if (f.hasImage === true) AND.push({ NOT: { image: '' } })
+  if (f.hasImage === false) AND.push({ image: '' })
+  if (f.hasTicketUrl === true) AND.push({ NOT: { ticketUrl: '' } })
+  if (f.hasTicketUrl === false) AND.push({ ticketUrl: '' })
+  if (f.hasExcerpt === true) AND.push({ NOT: { excerpt: '' } })
+  if (f.hasExcerpt === false) AND.push({ excerpt: '' })
+
+  return AND.length ? { AND } : {}
+}
+
+export async function getShowsForAdmin(
+  filters: AdminShowFilters,
+  { page = 1, perPage = ADMIN_SHOWS_PER_PAGE }: { page?: number; perPage?: number } = {},
+): Promise<{ items: ShowWithVenue[]; total: number }> {
+  const where = buildAdminWhere(filters)
+  const [items, total] = await Promise.all([
+    prisma.show.findMany({
+      where,
+      orderBy: { date: 'asc' },
+      skip: (page - 1) * perPage,
+      take: perPage,
+      include: withVenue,
+    }),
+    prisma.show.count({ where }),
+  ])
+  return { items, total }
+}
+
 export async function upsertVenue(name: string, slug: string, data?: Partial<Venue>): Promise<Venue> {
   return prisma.venue.upsert({
     where: { slug },


### PR DESCRIPTION
  - /admin/shows: server-rendered list of all shows (past and upcoming), 25/page, sorted by date asc
  - Filter panel: search (title/excerpt/genre), venue multi-select, date range, featured tri-state — URL-param driven, debounced text inputs
  - Pagination preserves active filters
  - Inline ★ toggle via toggleFeaturedAction (revalidates /admin/shows and /)
  - Dashboard links to Manage shows
  - getShowsForAdmin + AdminShowFilters in lib/shows.ts (no date >= today gate)