### PR TITLE
ux: whole resource card clickable, not just the bottom link

### DIFF
--- a/app/contact/page.module.css
+++ b/app/contact/page.module.css
@@ -132,20 +132,39 @@
 }
 
 .card {
+  display: block;
+  block-size: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+
+.cardBody {
   display: grid;
   grid-template-rows: auto auto 1fr auto;
   gap: var(--size-3);
   padding: var(--size-5);
+  block-size: 100%;
   border-radius: 12px;
   background-color: var(--color-bg-elevated);
   border: 1px solid var(--color-separator);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.card:hover {
+.card:hover .cardBody,
+.card:focus-visible .cardBody {
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
   border-color: var(--color-text-tertiary);
+}
+
+.card:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 12px;
+}
+
+.card:focus {
+  outline: none;
 }
 
 .category {
@@ -173,7 +192,7 @@
   color: var(--color-text-secondary);
 }
 
-.cardLink {
+.cta {
   justify-self: start;
   font-size: 0.8rem;
   font-weight: 600;
@@ -182,6 +201,7 @@
   text-transform: lowercase;
 }
 
-.cardLink:hover {
+.card:hover .cta,
+.card:focus-visible .cta {
   opacity: 70%;
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -293,17 +293,21 @@ export default async function ContactPage({ searchParams }: ContactPageProps) {
         />
         <ul className={classes.grid}>
           {filtered.map((r) => (
-            <li key={r.name} className={classes.card}>
-              <span className={classes.category}>{CATEGORY_LABEL[r.category]}</span>
-              <h3 className={classes.cardTitle}>{r.name}</h3>
-              <p className={classes.cardDesc}>{r.description}</p>
+            <li key={r.name}>
               <Link
-                className={classes.cardLink}
+                className={classes.card}
                 href={r.url}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {r.cta} →
+                <div className={classes.cardBody}>
+                  <span className={classes.category}>{CATEGORY_LABEL[r.category]}</span>
+                  <h3 className={classes.cardTitle}>{r.name}</h3>
+                  <p className={classes.cardDesc}>{r.description}</p>
+                  <span className={classes.cta} aria-hidden="true">
+                    {r.cta} →
+                  </span>
+                </div>
               </Link>
             </li>
           ))}


### PR DESCRIPTION
    - resource card now wrapped in one <Link> to the external URL — tapping anywhere on the card opens it (target=_blank), instead of the prior dead-zone where everything except the bottom cta would just focus the card
    - cta text kept as aria-hidden decorative since the whole card is the link, no redundant anchor for screen readers
    - focus-visible outline on the card for keyboard users; tap-focus ring no longer lingers after touch