### PR TITLE
feat: admin resources, mobile-friendly admin, multi-admin

### DIFF
--- a/actions/admin/resources.ts
+++ b/actions/admin/resources.ts
@@ -1,0 +1,122 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import prisma from '@/lib/prisma'
+import { slugifyCategory } from '@/lib/resources'
+
+type ResourceFormState = { error?: string; success?: boolean }
+
+async function resolveCategoryId(formData: FormData): Promise<string | null> {
+  const raw = String(formData.get('categoryId') ?? '').trim()
+  if (raw && raw !== '__new__') return raw
+  if (raw === '__new__') {
+    const name = String(formData.get('newCategoryName') ?? '').trim()
+    if (!name) return null
+    const slug = slugifyCategory(name)
+    const existing = await prisma.resourceCategory.findFirst({
+      where: { OR: [{ name }, { slug }] },
+    })
+    if (existing) return existing.id
+    const maxOrder = await prisma.resourceCategory.aggregate({
+      _max: { sortOrder: true },
+    })
+    const created = await prisma.resourceCategory.create({
+      data: {
+        name,
+        slug,
+        sortOrder: (maxOrder._max.sortOrder ?? 0) + 1,
+      },
+    })
+    return created.id
+  }
+  return null
+}
+
+function parseForm(formData: FormData) {
+  return {
+    name: String(formData.get('name') ?? '').trim(),
+    description: String(formData.get('description') ?? '').trim(),
+    url: String(formData.get('url') ?? '').trim(),
+    cta: String(formData.get('cta') ?? '').trim(),
+    sortOrder: Number(formData.get('sortOrder') ?? 0) || 0,
+  }
+}
+
+function validate(fields: ReturnType<typeof parseForm>, categoryId: string | null): string | null {
+  if (!fields.name) return 'Name is required'
+  if (!fields.description) return 'Description is required'
+  if (!fields.url) return 'URL is required'
+  if (!fields.cta) return 'CTA text is required'
+  if (!categoryId) return 'Category is required'
+  try {
+    new URL(fields.url)
+  } catch {
+    return 'URL must be a valid web address (include https://)'
+  }
+  return null
+}
+
+export async function createResourceAction(
+  _prev: ResourceFormState,
+  formData: FormData,
+): Promise<ResourceFormState> {
+  const fields = parseForm(formData)
+  const categoryId = await resolveCategoryId(formData)
+  const err = validate(fields, categoryId)
+  if (err) return { error: err }
+
+  const maxOrder = await prisma.resource.aggregate({ _max: { sortOrder: true } })
+  const order = fields.sortOrder || (maxOrder._max.sortOrder ?? 0) + 1
+
+  await prisma.resource.create({
+    data: {
+      name: fields.name,
+      description: fields.description,
+      url: fields.url,
+      cta: fields.cta,
+      sortOrder: order,
+      categoryId: categoryId!,
+    },
+  })
+
+  revalidatePath('/contact')
+  revalidatePath('/admin/resources')
+  redirect('/admin/resources')
+}
+
+export async function updateResourceAction(
+  _prev: ResourceFormState,
+  formData: FormData,
+): Promise<ResourceFormState> {
+  const id = String(formData.get('id') ?? '')
+  if (!id) return { error: 'Missing resource id' }
+  const fields = parseForm(formData)
+  const categoryId = await resolveCategoryId(formData)
+  const err = validate(fields, categoryId)
+  if (err) return { error: err }
+
+  await prisma.resource.update({
+    where: { id },
+    data: {
+      name: fields.name,
+      description: fields.description,
+      url: fields.url,
+      cta: fields.cta,
+      sortOrder: fields.sortOrder,
+      categoryId: categoryId!,
+    },
+  })
+
+  revalidatePath('/contact')
+  revalidatePath('/admin/resources')
+  redirect('/admin/resources')
+}
+
+export async function deleteResourceAction(formData: FormData): Promise<void> {
+  const id = String(formData.get('id') ?? '')
+  if (!id) return
+  await prisma.resource.delete({ where: { id } })
+  revalidatePath('/contact')
+  revalidatePath('/admin/resources')
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -16,6 +16,7 @@ export default async function AdminDashboardPage() {
           Submissions
           {submissionCount > 0 && <span className={classes.badge}>{submissionCount}</span>}
         </Link>
+        <Link href="/admin/resources" className={classes.navLink}>Resources</Link>
       </nav>
       <form action={logoutAction}>
         <button type="submit" className={classes.signOut}>Sign out</button>

--- a/app/admin/resources/[id]/page.tsx
+++ b/app/admin/resources/[id]/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import ResourceForm from '@/components/admin/resource-form'
+import { getAllResourceCategories, getResourceById } from '@/lib/resources'
+import classes from '../../shows/shows.module.css'
+
+export const metadata = {
+  title: 'Admin — Edit resource',
+  robots: { index: false, follow: false },
+}
+
+type Props = { params: Promise<{ id: string }> }
+
+export default async function EditResourcePage({ params }: Props) {
+  const { id } = await params
+  const [resource, categories] = await Promise.all([
+    getResourceById(id),
+    getAllResourceCategories(),
+  ])
+  if (!resource) notFound()
+
+  const defaults = {
+    id: resource.id,
+    name: resource.name,
+    description: resource.description,
+    url: resource.url,
+    cta: resource.cta,
+    sortOrder: resource.sortOrder,
+    categoryId: resource.categoryId,
+  }
+
+  return (
+    <section>
+      <div className={classes.header}>
+        <h1 className={classes.title}>Edit resource</h1>
+        <Link href="/admin/resources" className={classes.backLink}>← Back to resources</Link>
+      </div>
+      <ResourceForm mode="edit" categories={categories} defaults={defaults} />
+    </section>
+  )
+}

--- a/app/admin/resources/new/page.tsx
+++ b/app/admin/resources/new/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import ResourceForm from '@/components/admin/resource-form'
+import { getAllResourceCategories } from '@/lib/resources'
+import classes from '../../shows/shows.module.css'
+
+export const metadata = {
+  title: 'Admin — Add resource',
+  robots: { index: false, follow: false },
+}
+
+export default async function NewResourcePage() {
+  const categories = await getAllResourceCategories()
+
+  return (
+    <section>
+      <div className={classes.header}>
+        <h1 className={classes.title}>Add a resource</h1>
+        <Link href="/admin/resources" className={classes.backLink}>← Back to resources</Link>
+      </div>
+      <ResourceForm mode="create" categories={categories} />
+    </section>
+  )
+}

--- a/app/admin/resources/page.tsx
+++ b/app/admin/resources/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { getAllResources } from '@/lib/resources'
+import ResourcesTable from '@/components/admin/resources-table'
+import classes from '../shows/shows.module.css'
+
+export const metadata: Metadata = {
+  title: 'Admin — Resources',
+  robots: { index: false, follow: false },
+}
+
+export default async function AdminResourcesPage() {
+  const resources = await getAllResources()
+
+  return (
+    <section className={classes.page}>
+      <header className={classes.header}>
+        <h1 className={classes.title}>Resources</h1>
+        <div className={classes.headerActions}>
+          <p className={classes.count}>
+            {resources.length.toLocaleString()} resource{resources.length === 1 ? '' : 's'}
+          </p>
+          <Link href="/admin/resources/new" className={classes.buildLink}>+ Add resource</Link>
+        </div>
+      </header>
+      <ResourcesTable items={resources} />
+    </section>
+  )
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import ContactForm from '@/components/input/contact-form'
 import CategoryFilter from '@/components/input/category-filter'
+import { getAllResourceCategories, getAllResources } from '@/lib/resources'
 import classes from './page.module.css'
 
 export const metadata: Metadata = {
@@ -10,249 +11,36 @@ export const metadata: Metadata = {
   alternates: { canonical: '/contact' },
 }
 
-type Category =
-  | 'community'
-  | 'fund'
-  | 'humanitarian'
-  | 'antiwar'
-  | 'legal'
-  | 'indigenous'
-  | 'press'
-
-type Resource = {
-  name: string
-  description: string
-  url: string
-  cta: string
-  category: Category
-}
-
 const CONTACT = {
   email: 'contact@distortnewyork.com',
   donateUrl: 'https://donate.stripe.com/5kA7wegxI9Bme4g289',
 }
 
-const CATEGORY_ORDER: Category[] = [
-  'community',
-  'humanitarian',
-  'antiwar',
-  'legal',
-  'indigenous',
-  'fund',
-  'press',
-]
-
-const CATEGORY_LABEL: Record<Category, string> = {
-  community: 'Community',
-  fund: 'Mutual aid',
-  humanitarian: 'Humanitarian',
-  antiwar: 'Anti-war',
-  legal: 'Know your rights',
-  indigenous: 'Indigenous',
-  press: 'Press',
-}
-
-const RESOURCES: Resource[] = [
-  {
-    name: 'Mayday Space',
-    description: 'A home for movements, social justice activism, and community events in Brooklyn.',
-    url: 'https://maydayspace.org/',
-    cta: 'maydayspace.org',
-    category: 'community',
-  },
-  {
-    name: 'Save Project Reach',
-    description: 'Raising funds to help empower young people and marginalized communities.',
-    url: 'https://www.instagram.com/saveprojectreach/',
-    cta: '@saveprojectreach',
-    category: 'community',
-  },
-  {
-    name: 'Atlanta Solidarity Fund',
-    description:
-      'Bails out activists arrested for participating in social justice movements and helps them access lawyers.',
-    url: 'https://secure.actblue.com/donate/atlanta-solidarity-fund',
-    cta: 'contribute',
-    category: 'fund',
-  },
-  {
-    name: 'Medical Aid for Palestinians',
-    description: 'Urgent medical aid for Palestinians in Gaza, the West Bank, and refugee camps across the region.',
-    url: 'https://linktr.ee/MedicalAidforPalestinians',
-    cta: 'map.org.uk',
-    category: 'humanitarian',
-  },
-  {
-    name: 'UNRWA',
-    description:
-      'UN relief agency providing assistance, protection, and advocacy for Palestinian refugees across Gaza and the region.',
-    url: 'https://www.unrwa.org/',
-    cta: 'unrwa.org',
-    category: 'humanitarian',
-  },
-  {
-    name: "Palestine Children's Relief Fund",
-    description:
-      'Humanitarian medical relief for children in Palestine and the Middle East. Charity Navigator 4-star rated for 12+ years.',
-    url: 'https://www.pcrf.net/',
-    cta: 'pcrf.net',
-    category: 'humanitarian',
-  },
-  {
-    name: 'HEAL Palestine',
-    description: '501(c)(3) delivering humanitarian, educational, and medical aid to Gaza.',
-    url: 'https://www.healpalestine.org/',
-    cta: 'healpalestine.org',
-    category: 'humanitarian',
-  },
-  {
-    name: "Middle East Children's Alliance",
-    description: "Humanitarian aid, children's programs, and advocacy rooted in Palestine and the broader region.",
-    url: 'https://www.mecaforpeace.org/',
-    cta: 'mecaforpeace.org',
-    category: 'humanitarian',
-  },
-  {
-    name: 'Jewish Voice for Peace',
-    description: 'Jewish anti-occupation organizing for Palestinian liberation and ending US complicity in apartheid.',
-    url: 'https://www.jewishvoiceforpeace.org/',
-    cta: 'jewishvoiceforpeace.org',
-    category: 'community',
-  },
-  {
-    name: 'CODEPINK',
-    description: 'Grassroots anti-war organization opposing US militarism, sanctions, and foreign intervention.',
-    url: 'https://www.codepink.org/',
-    cta: 'codepink.org',
-    category: 'antiwar',
-  },
-  {
-    name: 'Quincy Institute',
-    description: 'Foreign-policy think tank advocating for restraint, diplomacy, and an end to endless war.',
-    url: 'https://quincyinst.org/',
-    cta: 'quincyinst.org',
-    category: 'antiwar',
-  },
-  {
-    name: 'Immigrant Defense Project',
-    description:
-      'Community defense, legal resources, and trainings to help people defend their rights against ICE and in immigration proceedings.',
-    url: 'https://www.immigrantdefenseproject.org/',
-    cta: 'immigrantdefenseproject.org',
-    category: 'legal',
-  },
-  {
-    name: 'National Immigration Law Center',
-    description: 'Defends and advances the rights of low-income immigrants through policy, litigation, and organizing.',
-    url: 'https://www.nilc.org/',
-    cta: 'nilc.org',
-    category: 'legal',
-  },
-  {
-    name: 'CHIRLA',
-    description:
-      'Coalition for Humane Immigrant Rights — deportation defense, know-your-rights education, and community organizing.',
-    url: 'https://www.chirla.org/',
-    cta: 'chirla.org',
-    category: 'legal',
-  },
-  {
-    name: 'RAICES',
-    description: 'Free and low-cost legal services for immigrants, refugees, and asylum seekers across Texas and beyond.',
-    url: 'https://www.raicestexas.org/',
-    cta: 'raicestexas.org',
-    category: 'legal',
-  },
-  {
-    name: 'NDN Collective',
-    description:
-      'Indigenous-led organization building Indigenous power through organizing, advocacy, philanthropy, and movement-building. Home of the LANDBACK campaign.',
-    url: 'https://ndncollective.org/',
-    cta: 'ndncollective.org',
-    category: 'indigenous',
-  },
-  {
-    name: 'Native American Rights Fund',
-    description:
-      'Nonprofit law firm dedicated to defending the rights of Native American tribes, organizations, and individuals nationwide.',
-    url: 'https://narf.org/',
-    cta: 'narf.org',
-    category: 'indigenous',
-  },
-  {
-    name: 'First Nations Development Institute',
-    description:
-      'Native-led nonprofit strengthening Native American economies and communities through grantmaking, advocacy, and technical assistance.',
-    url: 'https://www.firstnations.org/',
-    cta: 'firstnations.org',
-    category: 'indigenous',
-  },
-  {
-    name: "Lakota People's Law Project",
-    description:
-      'Advocacy, legal action, and direct organizing to protect Lakota and Indigenous rights — from MMIW to treaty rights to sacred lands.',
-    url: 'https://www.lakotalaw.org/',
-    cta: 'lakotalaw.org',
-    category: 'indigenous',
-  },
-  {
-    name: 'Democracy Now!',
-    description: 'Independent daily news program — war and peace, environment, and social justice movements worldwide.',
-    url: 'https://www.democracynow.org/',
-    cta: 'democracynow.org',
-    category: 'press',
-  },
-  {
-    name: 'The Intercept',
-    description: 'Investigative, adversarial journalism holding the powerful accountable.',
-    url: 'https://theintercept.com/',
-    cta: 'theintercept.com',
-    category: 'press',
-  },
-  {
-    name: 'Mondoweiss',
-    description: 'News and analysis covering Palestine, Israel, and the broader movement for justice.',
-    url: 'https://mondoweiss.net/',
-    cta: 'mondoweiss.net',
-    category: 'press',
-  },
-  {
-    name: 'The Electronic Intifada',
-    description: 'Palestinian-led publication reporting on the struggle for Palestinian freedom and equality.',
-    url: 'https://electronicintifada.net/',
-    cta: 'electronicintifada.net',
-    category: 'press',
-  },
-  {
-    name: 'Jacobin',
-    description: 'Leading voice on the American left — politics, economics, and culture from a socialist perspective.',
-    url: 'https://jacobin.com/',
-    cta: 'jacobin.com',
-    category: 'press',
-  },
-]
-
 interface ContactPageProps {
   searchParams: Promise<{ cat?: string }>
 }
 
-function isCategory(value: string | undefined): value is Category {
-  return CATEGORY_ORDER.includes(value as Category)
-}
-
 export default async function ContactPage({ searchParams }: ContactPageProps) {
   const { cat } = await searchParams
-  const activeCategory: Category | '' = isCategory(cat) ? cat : ''
+  const [resources, categories] = await Promise.all([
+    getAllResources(),
+    getAllResourceCategories(),
+  ])
 
-  const filtered = activeCategory
-    ? RESOURCES.filter((r) => r.category === activeCategory)
-    : RESOURCES
+  const categoryBySlug = new Map(categories.map((c) => [c.slug, c]))
+  const activeCategorySlug = cat && categoryBySlug.has(cat) ? cat : ''
 
-  const filterOptions = CATEGORY_ORDER.map((c) => ({
-    value: c,
-    label: CATEGORY_LABEL[c],
-    count: RESOURCES.filter((r) => r.category === c).length,
-  })).filter((o) => o.count > 0)
+  const filtered = activeCategorySlug
+    ? resources.filter((r) => r.category.slug === activeCategorySlug)
+    : resources
+
+  const filterOptions = categories
+    .map((c) => ({
+      value: c.slug,
+      label: c.name,
+      count: resources.filter((r) => r.category.slug === c.slug).length,
+    }))
+    .filter((o) => o.count > 0)
 
   return (
     <section className={classes.wrap}>
@@ -289,12 +77,12 @@ export default async function ContactPage({ searchParams }: ContactPageProps) {
         <h2 className={classes.sectionHeading}>Resources</h2>
         <CategoryFilter
           options={filterOptions}
-          active={activeCategory}
-          totalCount={RESOURCES.length}
+          active={activeCategorySlug}
+          totalCount={resources.length}
         />
         <ul className={classes.grid}>
           {filtered.map((r) => (
-            <li key={r.name}>
+            <li key={r.id}>
               <Link
                 className={classes.card}
                 href={r.url}
@@ -302,7 +90,7 @@ export default async function ContactPage({ searchParams }: ContactPageProps) {
                 rel="noopener noreferrer"
               >
                 <div className={classes.cardBody}>
-                  <span className={classes.category}>{CATEGORY_LABEL[r.category]}</span>
+                  <span className={classes.category}>{r.category.name}</span>
                   <h3 className={classes.cardTitle}>{r.name}</h3>
                   <p className={classes.cardDesc}>{r.description}</p>
                   <span className={classes.cta} aria-hidden="true">

--- a/components/admin/admin-nav.tsx
+++ b/components/admin/admin-nav.tsx
@@ -14,6 +14,7 @@ export default async function AdminNav() {
       <div className={classes.links}>
         <Link href="/admin/shows" className={classes.link}>Shows</Link>
         <Link href="/admin/submissions" className={classes.link}>Submissions</Link>
+        <Link href="/admin/resources" className={classes.link}>Resources</Link>
       </div>
     </nav>
   )

--- a/components/admin/delete-resource-button.tsx
+++ b/components/admin/delete-resource-button.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useTransition } from 'react'
+import { deleteResourceAction } from '@/actions/admin/resources'
+import classes from './delete-show-button.module.css'
+
+export default function DeleteResourceButton({ id, name }: { id: string; name: string }) {
+  const [pending, startTransition] = useTransition()
+
+  const handleClick = () => {
+    if (!confirm(`Delete resource "${name}"? This cannot be undone.`)) return
+    const fd = new FormData()
+    fd.set('id', id)
+    startTransition(() => {
+      deleteResourceAction(fd)
+    })
+  }
+
+  return (
+    <button type="button" onClick={handleClick} disabled={pending} className={classes.button}>
+      {pending ? '…' : 'Delete'}
+    </button>
+  )
+}

--- a/components/admin/resource-form.tsx
+++ b/components/admin/resource-form.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { useActionState, useState } from 'react'
+import type { ResourceCategory } from '@/lib/resources'
+import { createResourceAction, updateResourceAction } from '@/actions/admin/resources'
+import classes from './show-form.module.css'
+
+export type ResourceFormDefaults = {
+  id?: string
+  name?: string
+  description?: string
+  url?: string
+  cta?: string
+  sortOrder?: number
+  categoryId?: string
+}
+
+type Props = {
+  mode: 'create' | 'edit'
+  categories: ResourceCategory[]
+  defaults?: ResourceFormDefaults
+}
+
+export default function ResourceForm({ mode, categories, defaults }: Props) {
+  const action = mode === 'create' ? createResourceAction : updateResourceAction
+  const [state, formAction, pending] = useActionState(action, {})
+  const [categorySelection, setCategorySelection] = useState<string>(defaults?.categoryId ?? '')
+  const creatingCategory = categorySelection === '__new__'
+
+  const submitLabel = mode === 'create' ? 'Create resource' : 'Save changes'
+
+  return (
+    <form action={formAction} className={classes.form}>
+      {mode === 'edit' && defaults?.id && <input type="hidden" name="id" value={defaults.id} />}
+
+      {state?.error && <p className={classes.error}>{state.error}</p>}
+
+      <fieldset className={classes.section}>
+        <legend>Basics</legend>
+        <label className={classes.field}>
+          <span>Name</span>
+          <input name="name" required defaultValue={defaults?.name ?? ''} />
+        </label>
+        <label className={classes.field}>
+          <span>Description</span>
+          <textarea name="description" rows={4} required defaultValue={defaults?.description ?? ''} />
+        </label>
+        <label className={classes.field}>
+          <span>Category</span>
+          <select
+            name="categoryId"
+            required
+            value={categorySelection}
+            onChange={(e) => setCategorySelection(e.target.value)}
+          >
+            <option value="" disabled>Pick a category…</option>
+            {categories.map((c) => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+            <option value="__new__">+ Add a new category…</option>
+          </select>
+        </label>
+        {creatingCategory && (
+          <label className={classes.field}>
+            <span>New category name</span>
+            <input
+              name="newCategoryName"
+              required={creatingCategory}
+              placeholder="e.g. Climate"
+            />
+          </label>
+        )}
+      </fieldset>
+
+      <fieldset className={classes.section}>
+        <legend>Link</legend>
+        <label className={classes.field}>
+          <span>URL</span>
+          <input
+            name="url"
+            type="url"
+            required
+            defaultValue={defaults?.url ?? ''}
+            placeholder="https://…"
+          />
+        </label>
+        <label className={classes.field}>
+          <span>CTA text</span>
+          <input
+            name="cta"
+            required
+            defaultValue={defaults?.cta ?? ''}
+            placeholder="e.g. example.org or @handle"
+          />
+        </label>
+      </fieldset>
+
+      <fieldset className={classes.section}>
+        <legend>Ordering</legend>
+        <label className={classes.field}>
+          <span>Sort order</span>
+          <input
+            name="sortOrder"
+            type="number"
+            defaultValue={defaults?.sortOrder ?? 0}
+            placeholder="Lower numbers appear first"
+          />
+        </label>
+      </fieldset>
+
+      <button type="submit" className={classes.submit} disabled={pending}>
+        {pending ? 'Saving…' : submitLabel}
+      </button>
+    </form>
+  )
+}

--- a/components/admin/resources-table.tsx
+++ b/components/admin/resources-table.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link'
+import type { ResourceWithCategory } from '@/lib/resources'
+import DeleteResourceButton from './delete-resource-button'
+import classes from './show-table.module.css'
+
+type Props = { items: ResourceWithCategory[] }
+
+export default function ResourcesTable({ items }: Props) {
+  if (items.length === 0) {
+    return <p className={classes.empty}>No resources yet.</p>
+  }
+  return (
+    <div className={classes.wrap}>
+      <table className={classes.table}>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Category</th>
+            <th>CTA</th>
+            <th>Sort</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((r) => (
+            <tr key={r.id}>
+              <td className={classes.title}>
+                <Link href={`/admin/resources/${r.id}`} className={classes.titleLink}>
+                  {r.name}
+                </Link>
+              </td>
+              <td className={classes.clampCell} data-label="Category">
+                <div className={classes.clamp}>{r.category.name}</div>
+              </td>
+              <td className={classes.clampCell} data-label="CTA">
+                <div className={classes.clamp}>{r.cta}</div>
+              </td>
+              <td className={`${classes.num} ${classes.mobileHide}`} data-label="Sort">{r.sortOrder}</td>
+              <td className={classes.actionsCell}>
+                <div className={classes.actions}>
+                  <Link href={`/admin/resources/${r.id}`} className={classes.openBtn}>Edit</Link>
+                  <DeleteResourceButton id={r.id} name={r.name} />
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/lib/resources.ts
+++ b/lib/resources.ts
@@ -1,0 +1,34 @@
+import prisma from '@/lib/prisma'
+import type { ResourceModel, ResourceCategoryModel } from '@/lib/generated/prisma/models'
+
+export type Resource = ResourceModel
+export type ResourceCategory = ResourceCategoryModel
+export type ResourceWithCategory = ResourceModel & { category: ResourceCategoryModel }
+
+export async function getAllResources(): Promise<ResourceWithCategory[]> {
+  return prisma.resource.findMany({
+    include: { category: true },
+    orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+  })
+}
+
+export async function getResourceById(id: string): Promise<ResourceWithCategory | null> {
+  return prisma.resource.findUnique({
+    where: { id },
+    include: { category: true },
+  })
+}
+
+export async function getAllResourceCategories(): Promise<ResourceCategory[]> {
+  return prisma.resourceCategory.findMany({
+    orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+  })
+}
+
+export function slugifyCategory(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}

--- a/prisma/migrations/20260421065915_add_resources/migration.sql
+++ b/prisma/migrations/20260421065915_add_resources/migration.sql
@@ -1,0 +1,82 @@
+-- CreateTable
+CREATE TABLE "ResourceCategory" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ResourceCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Resource" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "cta" TEXT NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "categoryId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Resource_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ResourceCategory_name_key" ON "ResourceCategory"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ResourceCategory_slug_key" ON "ResourceCategory"("slug");
+
+-- CreateIndex
+CREATE INDEX "ResourceCategory_sortOrder_idx" ON "ResourceCategory"("sortOrder");
+
+-- CreateIndex
+CREATE INDEX "Resource_categoryId_idx" ON "Resource"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "Resource_sortOrder_idx" ON "Resource"("sortOrder");
+
+-- AddForeignKey
+ALTER TABLE "Resource" ADD CONSTRAINT "Resource_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "ResourceCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Seed: categories (idempotent; skips if a row already exists)
+INSERT INTO "ResourceCategory" ("id", "name", "slug", "sortOrder") VALUES
+  ('cat_community', 'Community', 'community', 1),
+  ('cat_humanitarian', 'Humanitarian', 'humanitarian', 2),
+  ('cat_antiwar', 'Anti-war', 'antiwar', 3),
+  ('cat_legal', 'Know your rights', 'legal', 4),
+  ('cat_indigenous', 'Indigenous', 'indigenous', 5),
+  ('cat_fund', 'Mutual aid', 'fund', 6),
+  ('cat_press', 'Press', 'press', 7)
+ON CONFLICT ("id") DO NOTHING;
+
+-- Seed: existing resources from app/contact/page.tsx
+INSERT INTO "Resource" ("id", "name", "description", "url", "cta", "sortOrder", "categoryId", "updatedAt") VALUES
+  ('res_mayday_space', 'Mayday Space', 'A home for movements, social justice activism, and community events in Brooklyn.', 'https://maydayspace.org/', 'maydayspace.org', 1, 'cat_community', CURRENT_TIMESTAMP),
+  ('res_save_project_reach', 'Save Project Reach', 'Raising funds to help empower young people and marginalized communities.', 'https://www.instagram.com/saveprojectreach/', '@saveprojectreach', 2, 'cat_community', CURRENT_TIMESTAMP),
+  ('res_atlanta_solidarity_fund', 'Atlanta Solidarity Fund', 'Bails out activists arrested for participating in social justice movements and helps them access lawyers.', 'https://secure.actblue.com/donate/atlanta-solidarity-fund', 'contribute', 3, 'cat_fund', CURRENT_TIMESTAMP),
+  ('res_medical_aid_palestinians', 'Medical Aid for Palestinians', 'Urgent medical aid for Palestinians in Gaza, the West Bank, and refugee camps across the region.', 'https://linktr.ee/MedicalAidforPalestinians', 'map.org.uk', 4, 'cat_humanitarian', CURRENT_TIMESTAMP),
+  ('res_unrwa', 'UNRWA', 'UN relief agency providing assistance, protection, and advocacy for Palestinian refugees across Gaza and the region.', 'https://www.unrwa.org/', 'unrwa.org', 5, 'cat_humanitarian', CURRENT_TIMESTAMP),
+  ('res_pcrf', 'Palestine Children''s Relief Fund', 'Humanitarian medical relief for children in Palestine and the Middle East. Charity Navigator 4-star rated for 12+ years.', 'https://www.pcrf.net/', 'pcrf.net', 6, 'cat_humanitarian', CURRENT_TIMESTAMP),
+  ('res_heal_palestine', 'HEAL Palestine', '501(c)(3) delivering humanitarian, educational, and medical aid to Gaza.', 'https://www.healpalestine.org/', 'healpalestine.org', 7, 'cat_humanitarian', CURRENT_TIMESTAMP),
+  ('res_meca', 'Middle East Children''s Alliance', 'Humanitarian aid, children''s programs, and advocacy rooted in Palestine and the broader region.', 'https://www.mecaforpeace.org/', 'mecaforpeace.org', 8, 'cat_humanitarian', CURRENT_TIMESTAMP),
+  ('res_jvp', 'Jewish Voice for Peace', 'Jewish anti-occupation organizing for Palestinian liberation and ending US complicity in apartheid.', 'https://www.jewishvoiceforpeace.org/', 'jewishvoiceforpeace.org', 9, 'cat_community', CURRENT_TIMESTAMP),
+  ('res_codepink', 'CODEPINK', 'Grassroots anti-war organization opposing US militarism, sanctions, and foreign intervention.', 'https://www.codepink.org/', 'codepink.org', 10, 'cat_antiwar', CURRENT_TIMESTAMP),
+  ('res_quincy', 'Quincy Institute', 'Foreign-policy think tank advocating for restraint, diplomacy, and an end to endless war.', 'https://quincyinst.org/', 'quincyinst.org', 11, 'cat_antiwar', CURRENT_TIMESTAMP),
+  ('res_immigrant_defense', 'Immigrant Defense Project', 'Community defense, legal resources, and trainings to help people defend their rights against ICE and in immigration proceedings.', 'https://www.immigrantdefenseproject.org/', 'immigrantdefenseproject.org', 12, 'cat_legal', CURRENT_TIMESTAMP),
+  ('res_nilc', 'National Immigration Law Center', 'Defends and advances the rights of low-income immigrants through policy, litigation, and organizing.', 'https://www.nilc.org/', 'nilc.org', 13, 'cat_legal', CURRENT_TIMESTAMP),
+  ('res_chirla', 'CHIRLA', 'Coalition for Humane Immigrant Rights — deportation defense, know-your-rights education, and community organizing.', 'https://www.chirla.org/', 'chirla.org', 14, 'cat_legal', CURRENT_TIMESTAMP),
+  ('res_raices', 'RAICES', 'Free and low-cost legal services for immigrants, refugees, and asylum seekers across Texas and beyond.', 'https://www.raicestexas.org/', 'raicestexas.org', 15, 'cat_legal', CURRENT_TIMESTAMP),
+  ('res_ndn_collective', 'NDN Collective', 'Indigenous-led organization building Indigenous power through organizing, advocacy, philanthropy, and movement-building. Home of the LANDBACK campaign.', 'https://ndncollective.org/', 'ndncollective.org', 16, 'cat_indigenous', CURRENT_TIMESTAMP),
+  ('res_narf', 'Native American Rights Fund', 'Nonprofit law firm dedicated to defending the rights of Native American tribes, organizations, and individuals nationwide.', 'https://narf.org/', 'narf.org', 17, 'cat_indigenous', CURRENT_TIMESTAMP),
+  ('res_first_nations', 'First Nations Development Institute', 'Native-led nonprofit strengthening Native American economies and communities through grantmaking, advocacy, and technical assistance.', 'https://www.firstnations.org/', 'firstnations.org', 18, 'cat_indigenous', CURRENT_TIMESTAMP),
+  ('res_lakota_law', 'Lakota People''s Law Project', 'Advocacy, legal action, and direct organizing to protect Lakota and Indigenous rights — from MMIW to treaty rights to sacred lands.', 'https://www.lakotalaw.org/', 'lakotalaw.org', 19, 'cat_indigenous', CURRENT_TIMESTAMP),
+  ('res_democracy_now', 'Democracy Now!', 'Independent daily news program — war and peace, environment, and social justice movements worldwide.', 'https://www.democracynow.org/', 'democracynow.org', 20, 'cat_press', CURRENT_TIMESTAMP),
+  ('res_intercept', 'The Intercept', 'Investigative, adversarial journalism holding the powerful accountable.', 'https://theintercept.com/', 'theintercept.com', 21, 'cat_press', CURRENT_TIMESTAMP),
+  ('res_mondoweiss', 'Mondoweiss', 'News and analysis covering Palestine, Israel, and the broader movement for justice.', 'https://mondoweiss.net/', 'mondoweiss.net', 22, 'cat_press', CURRENT_TIMESTAMP),
+  ('res_electronic_intifada', 'The Electronic Intifada', 'Palestinian-led publication reporting on the struggle for Palestinian freedom and equality.', 'https://electronicintifada.net/', 'electronicintifada.net', 23, 'cat_press', CURRENT_TIMESTAMP),
+  ('res_jacobin', 'Jacobin', 'Leading voice on the American left — politics, economics, and culture from a socialist perspective.', 'https://jacobin.com/', 'jacobin.com', 24, 'cat_press', CURRENT_TIMESTAMP)
+ON CONFLICT ("id") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,3 +81,30 @@ model Contact {
   status    ContactStatus @default(PENDING)
   createdAt DateTime      @default(now())
 }
+
+model ResourceCategory {
+  id        String     @id @default(cuid())
+  name      String     @unique
+  slug      String     @unique
+  sortOrder Int        @default(0)
+  createdAt DateTime   @default(now())
+  resources Resource[]
+
+  @@index([sortOrder])
+}
+
+model Resource {
+  id          String           @id @default(cuid())
+  name        String
+  description String
+  url         String
+  cta         String
+  sortOrder   Int              @default(0)
+  categoryId  String
+  category    ResourceCategory @relation(fields: [categoryId], references: [id])
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  @@index([categoryId])
+  @@index([sortOrder])
+}


### PR DESCRIPTION
  - Move /contact resources from hardcoded array to DB (Resource + ResourceCategory) with admin CRUD at /admin/resources. Migration seeds the existing 24 resources + 7 categories so nothing disappears on deploy. Public markup unchanged.
  - Reshape admin tables as cards below 768px; fix submissions column alignment; make Received column a sort toggle.
  - Support multiple admins via comma-separated ADMIN_USERNAME / ADMIN_PASSWORD_HASH.
  - Skip prisma migrate deploy when a commit doesn't touch prisma/migrations/; retry on advisory-lock contention.